### PR TITLE
Change the wildcard to --all (aka -A)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ The prompts are documented below in this README.
 
    cd {{repo_name}}
    git init .
-   git add *
+   git add --all
    git commit -m "Init technote"
 
 3. Customize the technote's Metadata and README

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -4,7 +4,10 @@
 
 {{ cookiecutter.description }}
 
-View this technote at {{ cookiecutter.url }}
+View this technote at {{ cookiecutter.url }} or see a preview of the
+current version in `this repo`_
+
+.. _this repo: ./index.rst
 
 {% if cookiecutter.docushare_url|length > 0 %}
    An authoritative version of this document is also available in LSST's Docushare: {{ cookiecutter.docushare_url }}


### PR DESCRIPTION
Hi Jonathan, I think using --all is preferable to the wildcard, that way files like .gitignore and .travis.yaml are picked up, which is presumably a feature. Also more platform independent. 
