### PR TITLE
Fix sphinx warning

### DIFF
--- a/{{cookiecutter.repo_name}}/index.rst
+++ b/{{cookiecutter.repo_name}}/index.rst
@@ -38,6 +38,7 @@
    Feel free to delete this instructional comment.
 
 :tocdepth: 1
+
 .. Please do not modify tocdepth; will be fixed when a new Sphinx theme is shipped.
 
 .. sectnum::


### PR DESCRIPTION
index.rst:41: WARNING: Field list ends without a blank line; unexpected unindent.