### PR TITLE
DM-11334: Update for documenteer 0.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,7 +211,7 @@ After the locale is set, re-try the cookiecutter_ command.
 
 ****
 
-Copyright 2015-2016 AURA/LSST
+Copyright 2015-2017 Association of Universities for Research in Astronomy, Inc.
 
 `lsst-technote-bootstrap` is open source (MIT license).
 

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -7,22 +7,29 @@
   .. image:: https://zenodo.org/badge/doi/10.5281/zenodo.#####.svg
      :target: http://dx.doi.org/10.5281/zenodo.#####
 
-{{ "#" * (cookiecutter.title|length + cookiecutter.series|length + cookiecutter.serial_number|length + 2) }}
-{{ cookiecutter.series }}-{{ cookiecutter.serial_number }} {{ cookiecutter.title }}
-{{ "#" * (cookiecutter.title|length + cookiecutter.series|length + cookiecutter.serial_number|length + 2) }}
+{{ "#" * cookiecutter.title|length }}
+{{ cookiecutter.title }}
+{{ "#" * cookiecutter.title|length }}
+
+{{ cookiecutter.series }}-{{ cookiecutter.serial_number }}
+{{ "=" * (cookiecutter.series|length + cookiecutter.serial_number|length + 1) }}
 
 {{ cookiecutter.description }}
 
-View this technote at {{ cookiecutter.url }} or see a preview of the current version in `this repo`_.
+**Links:**
 
+- Publication URL: {{ cookiecutter.url }}
+- Alternative editions: {{ cookiecutter.url }}/v
+- GitHub repository: https://github.com/{{ cookiecutter.github_namespace }}
+- Build system: https://travis-ci.org/{{ cookiecutter.github_namespace }}
 {% if cookiecutter.docushare_url|length > 0 %}
-An authoritative version of this document is also available in LSST's Docushare: {{ cookiecutter.docushare_url }}.
+- LSST Docushare: {{ cookiecutter.docushare_url }}.
 {% endif %}
 
 Build this technical note
 =========================
 
-You can clone this repository and build the technote locally with `Sphinx`_
+You can clone this repository and build the technote locally with `Sphinx`_:
 
 .. code-block:: bash
 

--- a/{{cookiecutter.repo_name}}/conf.py
+++ b/{{cookiecutter.repo_name}}/conf.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python
 #
 # Sphinx configuration file
-# see metadata.yaml in this repo for to update document-specific metadata
+# see metadata.yaml in this repo to update document-specific metadata
 
 import os
-from documenteer.designdocs import configure_sphinx_design_doc
+from documenteer.sphinxconfig.technoteconf import configure_technote
 
-# Ingest settings from metadata.yaml and use documenteer's
-# configure_sphinx_design_doc to build a Sphinx configuration that is
-# injected into this script's global namespace.
+# Ingest settings from metadata.yaml and use documenteer's configure_technote()
+# to build a Sphinx configuration that is injected into this script's global
+# namespace.
 metadata_path = os.path.join(os.path.dirname(__file__), 'metadata.yaml')
 with open(metadata_path, 'r') as f:
-    confs = configure_sphinx_design_doc(f)
+    confs = configure_technote(f)
 g = globals()
 g.update(confs)
+
+# Add intersphinx inventories as needed
+# http://www.sphinx-doc.org/en/stable/ext/intersphinx.html
+# Example:
+#
+#     intersphinx_mapping['python'] = ('https://docs.python.org/3', None)

--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,3 +1,1 @@
-Sphinx>=1.4.6
-documenteer>=0.1.9
-lsst-dd-rtd-theme
+documenteer[technote]>=0.2.1,<0.3


### PR DESCRIPTION
documenteer 0.2.x changes how technotes are configured. It also reduces the number of Python packages that must be managed to a technote to just `documenteer[technote]`; documenteer provides sphinx, sphinx extensions, and the sphinx theme.

Also improves the templated README to resemble the one we made for lsst-texmf-based documents.
