### PR TITLE
DM-6033: Add support for bibtex bibliographies

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -17,5 +17,8 @@
     "url": "https://{{ cookiecutter.series.lower() }}-{{ cookiecutter.serial_number }}.lsst.io",
     "description": "A short description of this document",
     "copyright_year": "2016",
-    "copyright_holder": "AURA/LSST"
+    "copyright_holder": "AURA/LSST",
+    "_copy_without_render": [
+        "*.bib"
+    ]
 }

--- a/{{cookiecutter.repo_name}}/Makefile
+++ b/{{cookiecutter.repo_name}}/Makefile
@@ -19,13 +19,14 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
+.PHONY: help clean html epub changes linkcheck refresh-bib
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html       to make standalone HTML files"
-	@echo "  epub       to make an epub"
-	@echo "  linkcheck  to check all external links for integrity"
+	@echo "  html         to make standalone HTML files"
+	@echo "  epub         to make an epub"
+	@echo "  linkcheck    to check all external links for integrity"
+	@echo "  refresh-bib  to update LSST bibliographies in lsstbib/"
 
 clean:
 	rm -rf $(BUILDDIR)/*
@@ -50,3 +51,8 @@ linkcheck:
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+refresh-bib:
+	refresh-lsst-bib -d lsstbib
+	@echo
+	@echo "Commit the new bibliographies:\n\n\tgit add lsstbib && git commit -m \"Update bibliographies.\""

--- a/{{cookiecutter.repo_name}}/README.rst
+++ b/{{cookiecutter.repo_name}}/README.rst
@@ -63,6 +63,16 @@ This technote's metadata is maintained in ``metadata.yaml``.
 In this metadata you can edit the technote's title, authors, publication date, etc..
 ``metadata.yaml`` is self-documenting with inline comments.
 
+Using the bibliographies
+========================
+
+The bibliography files in ``lsstbib/`` are copies from `lsst-texmf`_.
+You can update them to the current `lsst-texmf`_ versions with::
+
+   make refresh-bib
+
+Add new bibliography items to the ``local.bib`` file in the root directory (and later add them to `lsst-texmf`_).
+
 ****
 
 Copyright {{ cookiecutter.copyright_year }} {{ cookiecutter.copyright_holder }}
@@ -73,3 +83,4 @@ This work is licensed under the Creative Commons Attribution 4.0 International L
 .. _DM reStructuredText Style Guide: https://developer.lsst.io/docs/rst_styleguide.html
 .. _this repo: ./index.rst
 .. _Conda: http://conda.pydata.org/docs/
+.. _lsst-texmf: https://lsst-texmf.lsst.io

--- a/{{cookiecutter.repo_name}}/index.rst
+++ b/{{cookiecutter.repo_name}}/index.rst
@@ -50,3 +50,13 @@
    **This technote is not yet published.**
 
    {{ cookiecutter.description }}
+
+.. Add content here.
+
+.. .. rubric:: References
+
+.. Make in-text citations with: :cite:`bibkey`.
+
+.. .. bibliography:: local.bib lsstbib/books.bib lsstbib/lsst.bib lsstbib/lsst-dm.bib lsstbib/refs.bib lsstbib/refs_ads.bib
+..    :encoding: latex+latin
+..    :style: lsst_aa

--- a/{{cookiecutter.repo_name}}/index.rst
+++ b/{{cookiecutter.repo_name}}/index.rst
@@ -27,7 +27,6 @@
 
   .. figure:: /_static/filename.ext
      :name: fig-label
-     :target: http://target.link/url
 
      Caption text.
 

--- a/{{cookiecutter.repo_name}}/lsstbib/README.md
+++ b/{{cookiecutter.repo_name}}/lsstbib/README.md
@@ -10,5 +10,5 @@ git commit -m "Update lsst bibliographies"
 ```
 
 Add new bibliography items specifically for this technote to the `local.bib` file in the root directory of this technote.
-Later, you can add these bibliography items to `lsst-texmf` and remove them from `local.bib` so that other documents can use the reference.
+Later, you should add these bibliography items to `lsst-texmf` and remove them from `local.bib` so that other documents can use the reference.
 See the [lsst-texmf docs for instructions](https://lsst-texmf.lsst.io/developer.html#updating-bibliographies).

--- a/{{cookiecutter.repo_name}}/lsstbib/README.md
+++ b/{{cookiecutter.repo_name}}/lsstbib/README.md
@@ -1,0 +1,14 @@
+# lsstbib
+
+This directory contains local copies of LSST's common LaTeX bibliographies from [lsst-texmf](https://github.com/lsst/lsst-texmf/tree/master/texmf/bibtex/bib).
+The recommended way to update these files is with (from the root technote directory):
+
+```
+make refresh-bib
+git add lsstbib
+git commit -m "Update lsst bibliographies"
+```
+
+Add new bibliography items specifically for this technote to the `local.bib` file in the root directory of this technote.
+Later, you can add these bibliography items to `lsst-texmf` and remove them from `local.bib` so that other documents can use the reference.
+See the [lsst-texmf docs for instructions](https://lsst-texmf.lsst.io/developer.html#updating-bibliographies).

--- a/{{cookiecutter.repo_name}}/lsstbib/books.bib
+++ b/{{cookiecutter.repo_name}}/lsstbib/books.bib
@@ -1,0 +1,287 @@
+% Books file
+% Enter here books and proceedings which are referred to.
+%
+
+@Proceedings{Adass08,
+  title = "{Astronomical Data Analysis Software and Systems XVIII}",
+  booktitle = {Astronomical Data Analysis Software and Systems XVIII},
+  year = 2009,
+  series = {Astronomical Society of the Pacific Conference Series},
+  volume = 411,
+  editor = {{Bohlender}, D.~A. and {Durand}, D. and {Dowler}, P.},
+  month = sep,
+  adsurl = {http://adsabs.harvard.edu/abs/2009ASPC..411.....B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Book{Dierckx:1995,
+  author =       {P.~Dierckx},
+  title =        {{C} and {S}urface {F}itting with {S}plines},
+  year =         1995,
+  publisher =    {Oxford Science Publications, Oxford University
+                  Press},
+  edition =      {Paperback}
+}
+
+@Book{Greenbaum1997,
+  author =       {A.~Greenbaum},
+  title =        {{I}terative {M}ethods for {S}olving {L}inear
+                  {S}ystems},
+  year =         1997,
+  publisher =    {SIAM}
+}
+
+@Book{Perryman2009,
+  author =       {Michael ~Perryman},
+  title =        {{A}stronomical {A}pplications of {A}strometry: Ten
+                  Years of Exploitation of the Hipparcos Satellite
+                  Data},
+  year =         2009,
+  publisher =    {Cambridge University Press}
+}
+
+@book{Perryman2010,
+  title =        {The Making of History's Greatest Star Map},
+  author =       {Perryman, A.C.},
+  isbn =         9783642116025,
+  lccn =         2010922053,
+  series =       {Astronomers' universe},
+  url =          {http://books.google.es/books?id=P-5pZ8GNuPIC},
+  year =         2010,
+  publisher =    {Springer}
+}
+
+@proceedings{TDUG,
+  title =        {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.}
+}
+
+@Book{Will:1993,
+  author =       {C.~Will},
+  title =        {{T}heory and experiment in gravitational physics},
+  year =         1993,
+  publisher =    {Cambridge University Press},
+  edition =      2
+}
+
+@Book{asp:fomalont,
+  author =       {J.A.~Zensus, P.J.~Napier, P.J.~Napier},
+  title =        {Very Long Baseline Interferometry and the VLBA },
+  publisher =    {Astronomical Socienty of the Pacific,},
+  year =         1995,
+  edition =      { ASP Conference Series Vol. 82}
+}
+
+@Book{book:bayesanalysis,
+  author =       { P.~C.~Gregory},
+  title =        { {B}ayesian Logical {D}ata {A}nalysis for the
+                  Physical Sciences },
+  publisher =    { Cambridge University Press},
+  year =         2010,
+  edition =      1
+}
+
+@Book{book:hamilton,
+  author =       { Thomas ~L.~Hankins},
+  title =        { {S}ir {W}illiam {R}owan {H}amilton },
+  publisher =    { The Johns Hopkins University Press},
+  year =         1980
+}
+
+@Book{book:newhip,
+  author =       {Floor van Leeuwen},
+  title =        {{H}ipparcos, the {N}ew {R}eduction of the {R}aw
+                  {D}ata},
+  publisher =    {Springer },
+  year =         2007,
+  edition =      {{A}strophysics and {S}pace {S}cience
+                  {L}ibrary. {V}ol. 350}
+}
+
+@Book{book:numericalrecipes,
+  author =       { W.~H.~Press and S.~A.~Teukolsky and
+                  W.~T.~Vetterling and B.~P.~Flannery },
+  title =        { {N}umerical {R}ecipes in {C} },
+  publisher =    { Cambridge University Press},
+  year =         2002,
+  edition =      2
+}
+
+%THIS exists in ADS - look in gaia_refs_ads ....
+
+@Book{book:orighip,
+  author =       {Floor van {L}eeuwen},
+  title =        {The {H}ipparcos {M}ission},
+  publisher =    {Springer},
+  year =         1997,
+  edition =      {{S}pace {S}cience {R}eviews, {V}ol.81}
+}
+
+@Book{book:patterns,
+  author =       { E.~Gamma and R.~Helm and R.~Johnson and
+                  J.~Vlissides },
+  title =        { {D}esign {P}atterns: {E}lements of {R}eusable
+                  {O}bject-{O}riented {S}oftware },
+  publisher =    { Addison-Wesley Professional Computing Series},
+  year =         1994,
+}
+
+@Book{book:projectmanagement,
+  author =       { D.~Lock},
+  title =        { {P}roject {P}hasing and {P}lanning },
+  publisher =    { Gower},
+  year =         2000,
+  edition =      7
+}
+
+@Book{book:sivia,
+  author =       { D.S.~Sivia},
+  title =        { {D}ata {A}nalysis. {A} {B}ayesian {T}utorial},
+  publisher =    { OUP},
+  year =         1996,
+  edition =      1
+}
+
+@book{collins2001good,
+  title =        {Good to Great: Why Some Companies Make the
+                  Leap...And Others Don't},
+  author =       {Collins, J.},
+  isbn =         9780066620992,
+  lccn =         00102481,
+  url =          {http://books.google.es/books?id=Q7ja95uwUT4C},
+  year =         2001,
+  publisher =    {HarperCollins}
+}
+
+@Book{deBoor:2001,
+  author =       {C.~de~Boor},
+  title =        {{A} {P}ractical {G}uide to {S}plines},
+  year =         2001,
+  publisher =    {Springer},
+  edition =      {Revised}
+}
+
+@Book{handy1993understanding,
+  author =       {Handy, Charles},
+  title =        {Understanding organizations},
+  publisher =    {Penguin Books},
+  year =         1993,
+  address =      {London, England New York, N.Y., USA},
+  isbn =         0140156038
+}
+
+@Book{hip:catalogue,
+  author =       {ESA },
+  title =        { {T}he {H}ipparcos and {T}ycho {C}atalogues },
+  institution =  {ESA},
+  year =         1997,
+  note =         {ESA SP-1200},
+  publisher =    {ESA}
+}
+
+@Book{it:effectivejava,
+  author =       {J.~Bloch },
+  title =        {Writing Effective Java},
+  publisher =    { Addison-Wesley },
+  year =         2001,
+  edition =      {1st}
+}
+
+@Book{it:javaspec,
+  author =       {J.~Gosling and B.~Joy and G.~Steele },
+  title =        { {T}he {J}ava {L}anguage {S}pecification },
+  publisher =    { Addison-Wesley },
+  year =         2000,
+  edition =      {2nd}
+}
+
+@Book{it:rup,
+  author =       {Philippe Kruchten },
+  title =        { The Rational Unified Process: An Introduction },
+  publisher =    {Addison-Wesley Professional},
+  year =         2003,
+  edition =      {3rd}
+}
+
+@Book{it:uml,
+  author =       { Grady Booch and James Rumbaugh and Ivar Jacobson },
+  title =        { The Unified Modeling Language User Guide},
+  publisher =    {Addison-Wesley Professional},
+  year =         2005,
+  edition =      {2nd}
+}
+
+@Book{it:usdp,
+  author =       {Ivar Jacobson and Grady Booch and James Rumbaugh },
+  title =        { The Unified Software Development Process },
+  publisher =    {Addison-Wesley Professional},
+  year =         1999,
+  edition =      {1st}
+}
+
+@Book{it:xp,
+  author =       { K.~Beck },
+  title =        { {E}xtreme {P}rogramming {E}xplained: {E}mbrace
+                  {C}hange},
+  publisher =    { Addison-Wesley },
+  year =         1999,
+  edition =      {1st}
+}
+
+@Book{kane:1983,
+  author =       {T.~R.~Kane and P.~W.~Likins and D.~A.~Levinson},
+  title =        {{S}pacecraft dynamics},
+  year =         1983,
+  publisher =    {McGraw Hill Book Company},
+  edition =      1
+}
+
+@Book{korn:1961,
+  author =       {G.~A.~Korn and T.~M. Korn},
+  title =        {{M}athematical handbook for scientists and
+                  engineers},
+  year =         1961,
+  publisher =    {McGraw Hill Book Company},
+  edition =      1
+}
+
+@Book{NAP21886,
+  author    = {{National Academies of Sciences, Engineering, and Medicine}},
+  title     = "Future Directions for NSF Advanced Computing Infrastructure to Support U.S. Science and Engineering in 2017--2020",
+  isbn      = "978-0-309-38961-7",
+  doi       = "10.17226/21886",
+  abstract  = "Advanced computing capabilities are used to tackle a rapidly growing range of challenging science and engineering problems, many of which are compute- and data-intensive as well. Demand for advanced computing has been growing for all types and capabilities of systems, from large numbers of single commodity nodes to jobs requiring thousands of cores; for systems with fast interconnects; for systems with excellent data handling and management; and for an increasingly diverse set of applications that includes data analytics as well as modeling and simulation. Since the advent of its supercomputing centers, the National Science Foundation (NSF) has provided its researchers with state-of-the-art computing systems. The growth of new models of computing, including cloud computing and publically available by privately held data repositories, opens up new possibilities for NSF. \n\nIn order to better understand the expanding and diverse requirements of the science and engineering community and the importance of a new broader range of advanced computing infrastructure, the NSF requested that the National Research Council carry out a study examining anticipated priorities and associated tradeoffs for advanced computing. Future Directions for NSF Advanced Computing Infrastructure to Support U.S. Science and Engineering in 2017-2020 provides a framework for future decision-making about NSF\u2019s advanced computing strategy and programs. It offers recommendations aimed at achieving four broad goals: (1) position the U.S.  for continued leadership in science and engineering, (2) ensure that resources meet community needs, (3) aid the scientific community in keeping up with the revolution in computing, and (4) sustain the infrastructure for advanced computing.",
+  year      = 2016,
+  publisher = "The National Academies Press",
+  address   = "Washington, DC"
+}
+
+@Book{vanDerVorst2003,
+  author =       {H.~van der Vorst},
+  title =        {{I}terative {K}rylov {M}ethods for {L}arge {L}inear
+                  {S}ystems},
+  year =         2003,
+  publisher =    {Cambridge University Press}
+}
+
+@Book{wertz:1978,
+  author =       {James.~R.~Wertz(Editor)},
+  title =        {{S}pacecraft {A}ttitude {D}etermination and
+                  {C}ontrol},
+  year =         1978,
+  publisher =    {Kluwer Academic Publishers},
+  edition =      1
+}
+
+@book{Obe:2015:PA:2834495,
+  author = {Obe, Regina O. and Hsu, Leo S.},
+  title = {PostGIS in Action},
+  year = {2015},
+  isbn = {1617291390, 9781617291395},
+  edition = {2nd},
+  publisher = {Manning Publications Co.},
+  address = {Greenwich, CT, USA},
+}

--- a/{{cookiecutter.repo_name}}/lsstbib/lsst-dm.bib
+++ b/{{cookiecutter.repo_name}}/lsstbib/lsst-dm.bib
@@ -1,0 +1,2543 @@
+%% BibTeX bibliography file for LSST Data Management
+
+%% Includes entries for published papers, poster presentations,
+%% and talks. Does not include DocuShare entries.
+
+%% Use ADS entry if available.
+%% Use publisher entry if ADS entry not available.
+%% If no publisher entry, use key format "YYYYauthor-event"
+
+@INPROCEEDINGS{2002SPIE.4844..225C,
+   author = {{Connolly}, A. and {Boroson}, T.~A.},
+    title = "{Design Decisions for Data Management with the LSST}",
+booktitle = {Observatory Operations to Optimize Scientific Return III},
+     year = 2002,
+   series = {\procspie},
+   volume = 4844,
+   editor = {{Quinn}, P.~J.},
+    month = dec,
+    pages = {225-231},
+      doi = {10.1117/12.460742},
+   adsurl = {http://adsabs.harvard.edu/abs/2002SPIE.4844..225C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{2002connolly-adass,
+    author = {A. Connolly},
+    title = "{Data Management for the LSST}",
+     year = 2002,
+    month = oct,
+booktitle = {Astronomical Data Analysis Software and Systems XII, Baltimore},
+     note = {Invited talk. Paper not submitted to proceedings.},
+ abstract = "{The Large-aperture Synoptic Survey Telescope (LSST) represents the next
+              generation of wide-field survey telescopes. With repeated scans of the sky on
+              timescales ranging from a few minutes to several years it will be one of the
+              first of the wide-area survey facilities to open up the study of the time domain
+              in astrophysics. The scientific returns from such an approach are numerous,
+              ranging from the dynamics of near-Earth asteroids and Kuiper-belt objects
+              through to the detection of intermediate and high redshift supernovae. We will
+              discuss here the impact that such a diverse range of sci- entific questions will
+              have on the analysis and management of the data flow from such a telescope. We
+              will focus on a number of areas that must be addressed in order for the
+              successful operation of the LSST. These will include: a) the computational
+              challenge presented by a data rate in excess of 300GB per hour b) the impact of
+              the optical design on the photometric accuracy and image quality of the system
+              together with how this translates into implementing efficient techniques for
+              measuring the differ- ences between repeated observations or for co-adding
+              multiple images to construct a deep image of the sky c) the impact on the design
+              of the software due to the require- ment that we be able to detect variability
+              over a very broad range of temporal scales (from almost real-time though to
+              several years). Throughout we will discuss the cur- rent state-of-the-art in
+              analysis software and algorithms and how they might be expected to scale with
+              the increase in computational resources over the coming decade. We will then
+              identify which computational data management challenges we must address in the
+              near future.}",
+}
+
+@INPROCEEDINGS{2002AAS...20113405C,
+  author =       {{Connolly}, A. and {LSST Team}},
+  title =        "{Managing the Data Flow from the LSST}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2002,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       34,
+  month =        dec,
+  pages =        {\#134.05},
+  adsurl =       {http://adsabs.harvard.edu/abs/2002AAS...20113405C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2004SPIE.5489..705C,
+  author =       {{Claver}, C.~F. and {Sweeney}, D.~W. and {Tyson},
+                  J.~A. and {Althouse}, B. and {Axelrod}, T.~S. and
+                  {Cook}, K.~H. and {Daggert}, L.~G. and {Kantor},
+                  J.~C. and {Kahn}, S.~M. and {Krabbendam}, V.~L. and
+                  {Pinto}, P. and {Sebag}, J. and {Stubbs}, C. and
+                  {Wolff}, S.~C.  },
+  title =        "{Project status of the 8.4-m LSST}",
+  booktitle =    {Ground-based Telescopes},
+  year =         2004,
+  series =       {Proc.\ SPIE},
+  volume =       5489,
+  editor =       {{Oschmann}, Jr., J.~M.},
+  month =        oct,
+  pages =        {705-716},
+  doi =          {10.1117/12.561728},
+  adsurl =       {http://adsabs.harvard.edu/abs/2004SPIE.5489..705C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2004AAS...20510811A,
+  author =       {{Axelrod}, T. and {Connolly}, A. and {Ivezic},
+                  Z. and {Kantor}, J. and {Lupton}, R. and {Plante},
+                  R. and {Stubbs}, C. and {Wittman}, D.  },
+  title =        "{The LSST Data Processing Pipeline}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2004,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       36,
+  month =        dec,
+  pages =        {\#108.11},
+  adsurl =       {http://adsabs.harvard.edu/abs/2004AAS...20510811A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2004AAS...20510812B,
+  author =       {{Becker}, A.~C. and {Rest}, A. and {Miknaitis},
+                  G. and {Smith}, R.~C. and {Stubbs}, C.},
+  title =        "{LSST : Image Subtraction {\amp} Transient Detection
+                  Techniques}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2004,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       36,
+  month =        dec,
+  pages =        {\#108.12},
+  adsurl =       {http://adsabs.harvard.edu/abs/2004AAS...20510812B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Unpublished{2005kantor-status,
+  author =       {Jeff Kantor and Tim Axelrod},
+  title =        "{LSST Data Management Status}",
+  url =
+                  {http://www.slideshare.net/datacenters/sweeney-dm-status-review-20050322ppt},
+  month =        mar,
+  year =         2005,
+  note =         {Presented at DM Status Review},
+}
+
+@Unpublished{2005axelrod-htu,
+  author =       {Tim Axelrod},
+  title =        "{Events in the LSST}",
+  url =
+                  {http://wiki.ivoa.net/internal/IVOA/VOEventSchedule/tim_axelrod.ppt},
+  month =        apr,
+  year =         2005,
+  note =         {Presented at the IVOA VOEvent Workshop, Pasadena},
+}
+
+@INPROCEEDINGS{2005AAS...207.2629B,
+  author =       {{Becker}, A. and {Axelrod}, T. and {Ivezic}, Z. and
+                  {Lupton}, R. and {Silvestri}, N. and {Rest}, A.},
+  title =        "{The LSST Image Processing Pipeline}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2005,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       37,
+  month =        dec,
+  pages =        1206,
+  adsurl =       {http://adsabs.harvard.edu/abs/2005AAS...207.2629B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005AAS...207.2630A,
+  author =       {{Axelrod}, T. and {Becker}, A. and {Connolly},
+                  A. and {Cook}, K. and {Lupton}, R. and {Nikolaev},
+                  S. and {Rest}, A. and {Silvestri}, N. and {Smith},
+                  C.},
+  title =        "{The LSST Detection and Association Pipelines}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2005,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       37,
+  month =        dec,
+  pages =        1207,
+  adsurl =       {http://adsabs.harvard.edu/abs/2005AAS...207.2630A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005AAS...207.2632K,
+  author =       {{Kubica}, J. and {Axelrod}, T. and {Barnard}, K. and
+                  {Connolly}, A. and {Denneau}, L. and {Efrat}, A. and
+                  {Heasley}, J. and {Jedicke}, R. and {Moon}, B. and
+                  {Moore}, A. and {Morris}, S. and {Rao}, P.},
+  title =        "{Efficiently Tracking Moving Sources in the LSST}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2005,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       37,
+  month =        dec,
+  pages =        1207,
+  adsurl =       {http://adsabs.harvard.edu/abs/2005AAS...207.2632K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005AAS...207.2633B,
+  author =       {{Becla}, J. and {Nikolaev}, S. and {Abdulla}, G. and
+                  {Szalay}, A.~S. and {Nieto-Santisteban}, M. and
+                  {Thakar}, A. and {Axelrod}, T. and {Gray}, J. and
+                  {Pike}, R. and {Rosing}, W.},
+  title =        "{LSST Data Access Overview}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2005,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       37,
+  month =        dec,
+  pages =        1207,
+  adsurl =       {http://adsabs.harvard.edu/abs/2005AAS...207.2633B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005AAS...207.2634D,
+  author =       {{Dossa}, D. and {Matarazzo}, C. and {Marshall},
+                  S. and {Smith}, C. and {Lambert}, R. and {Butler},
+                  M. and {Cribbs}, C. and {Plante}, R. and {Sweeney},
+                  D. and {Kantor}, J.},
+  title =        "{LSST Data Management Infrastructure}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2005,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       37,
+  month =        dec,
+  pages =        1207,
+  adsurl =       {http://adsabs.harvard.edu/abs/2005AAS...207.2634D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2006AAS...209.8607A,
+  author =       {{Axelrod}, T.~S. and {Allsman}, R. and {Becker},
+                  A. and {Becla}, J. and {Connolly}, A. and {Cook},
+                  K. and {Gray}, J. and {Jagatheesan}, A. and
+                  {Kantor}, J. and {Nieto-Santisteban}, M. and
+                  {Nikolaev}, S. and {Owen}, R. and {Pike}, R. and
+                  {Plante}, R. and {Silvestri}, N. and {Smith}, C. and
+                  {Szalay}, A. and {Thakar}, A. and {Tyson}, J.~A. and
+                  {LSST Collaboration}},
+  title =        "{The LSST Data Products}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2006,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       38,
+  month =        dec,
+  pages =        1018,
+  adsurl =       {http://adsabs.harvard.edu/abs/2006AAS...209.8607A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@inproceedings{2006dossa-spie,
+  Author =       {Dossa, D. and Smith, R. and Lambert, R. and Plante,
+                  R. and Butler M. and Cribbs, C. and Kantor, J.},
+  Booktitle =    {Observatory Operations: Strategies, Processes, and
+                  Systems},
+  Editor =       {Silva, David R. and Doxsey, Rodger E.},
+  Date-Added =   {2010-11-19 14:52:39 -0700},
+  Date-Modified ={2011-03-03 13:22:15 -0700},
+  Organization = {SPIE},
+  Publisher =    {SPIE},
+  Series =       {Astronomical Telescopes and Instrumentation},
+  Title =        {LSST Data Management Infrastructure},
+  Volume =       6270,
+  Year =         2006
+}
+
+@INPROCEEDINGS{2006SPIE.6270E..0RB,
+  author =       {{Becla}, J. and {Hanushevsky}, A. and {Nikolaev},
+                  S. and {Abdulla}, G. and {Szalay}, A. and
+                  {Nieto-Santisteban}, M. and {Thakar}, A. and {Gray},
+                  J.},
+  title =        "{Designing a multi-petabyte database for LSST}",
+  booktitle =    {Observatory Operations: Strategies, Processes, and
+                  Systems},
+  editor =       {Silva, David R. and Doxsey, Rodger E.},
+  year =         2006,
+  series =       {Proc. SPIE},
+  volume =       6270,
+  eprint =       {cs/0604112},
+  month =        jun,
+  eid =          {62700R},
+  pages =        0,
+  doi =          {10.1117/12.671721},
+  adsurl =       {http://adsabs.harvard.edu/abs/2006SPIE.6270E..0RB},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2006SPIE.6274E..0PK,
+  author =       {{Kantor}, J.~P.},
+  title =        "{Managing the evolution of the LSST data management
+                  system}",
+  booktitle =    {Advanced Software and Control for Astronomy},
+  year =         2006,
+  series =       {Proc.\ SPIE},
+  editor =       {Hilton Lewis and Alan Bridger},
+  volume =       6274,
+  month =        jun,
+  eid =          {62740P},
+  pages =        0,
+  doi =          {10.1117/12.671685},
+  adsurl =       {http://adsabs.harvard.edu/abs/2006SPIE.6274E..0PK},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2006ASPC..351..103A,
+  author =       {{Axelrod}, T.~S.},
+  title =        "{The Large Synoptic Survey Telescope}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XV},
+  year =         2006,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       351,
+  editor =       {{Gabriel}, C. and {Arviset}, C. and {Ponz}, D. and
+                  {Enrique}, S.  },
+  month =        jul,
+  pages =        103,
+  adsurl =       {http://adsabs.harvard.edu/abs/2006ASPC..351..103A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{2007becker-htu,
+  author =       {Andy Becker},
+  title =        "{Transient object detection and classification}",
+  note =         {Hot-wiring the Transient Universe: a Joint VOEvent \& HTN Workshop
+                  June 4 - 7, 2007, Tucson, Arizona},
+  url =          {http://wiki.ivoa.net/twiki/bin/view/IVOA/HotwiredWorkshop},
+  month =        jun,
+  year =         2007
+}
+
+@misc{2007lim-ieee,
+  author =       {K.-T. Lim},
+  title =        {Preparing for Scores of Petabytes},
+  note =         {IEEE Mass Storage Symposium, San Diego, CA,
+                  September 26, 2007},
+  month =        sep,
+  year =         2007
+}
+
+@inproceedings{2007AAS...21113726A,
+  Adsnote =      {Provided by the SAO/NASA Astrophysics Data System},
+  Adsurl =       {http://adsabs.harvard.edu/abs/2007AAS...21113726A},
+  Author =       {Axelrod, T. and Becla, J. and Connolly, A. and
+                  Dossa, D. and Jagatheesan, A. and Kantor, J. and
+                  Levine, D. and Lupton, R. and Plante, R. and Smith,
+                  C. and Thakar, A. and Tyson, J.A. and LSST Data
+                  Management Team},
+  Booktitle =    {American Astronomical Society Meeting Abstracts},
+  Date-Added =   {2008-07-07 13:57:19 -0700},
+  Date-Modified ={2011-03-03 13:26:15 -0700},
+  Month =        dec,
+  Pages =        {\#137.26-+},
+  Series =       {American Astronomical Society Meeting Abstracts},
+  Title =        {The LSST Data Challenges},
+  Volume =       211,
+  Year =         2007
+}
+
+@INPROCEEDINGS{2007AAS...21113724L,
+  author =       {{Levine}, D.~A. and {Mannings}, V. and {Cutri},
+                  R. and {Dodd}, S. and {Claver}, C. and {Kantor},
+                  J. and {Axelrod}, T. and {Tyson}, T. and {Kahn},
+                  S. and {Ivezic}, Z. and {Sweeny}, D. and {Monet},
+                  D. and {Gilmore}, K. and {Schalk}, T. and {LSST
+                  Team}},
+  title =        "{The Science Data Quality Assessement System for
+                  LSST}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2007,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       39,
+  month =        dec,
+  pages =        {\#137.24},
+  adsurl =       {http://adsabs.harvard.edu/abs/2007AAS...21113724L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2007ASPC..371..142A,
+  author =       {{Axelrod}, T.},
+  title =        "{Photometric Calibration - An Intriguing Statistical
+                  Problem for the LSST}",
+  booktitle =    {Statistical Challenges in Modern Astronomy IV},
+  year =         2007,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       371,
+  editor =       {{Babu}, G.~J. and {Feigelson}, E.~D.},
+  month =        nov,
+  pages =        142,
+  adsurl =       {http://adsabs.harvard.edu/abs/2007ASPC..371..142A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@inproceedings{2007ASPC..376....3K,
+  Adsnote =      {Provided by the SAO/NASA Astrophysics Data System},
+  Adsurl =       {http://adsabs.harvard.edu/abs/2007ASPC..376....3K},
+  Author =       {Kantor, J. and Axelrod, T. and Becla, J. and Cook,
+                  K. and Nikolaev, S. and Gray, J. and Plante, R. and
+                  Nieto-Santisteban, M. and Szalay, A. and Thakar, A.},
+  Booktitle =    {Astronomical Data Analysis Software and Systems XVI},
+  Date-Added =   {2008-07-07 13:58:07 -0700},
+  Date-Modified ={2008-07-07 14:04:11 -0700},
+  Editor =       {{Shaw}, R.~A. and {Hill}, F. and {Bell}, D.~J.},
+  Month =        oct,
+  Pages =        {3-+},
+  Series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  Title =        {Designing for Peta-Scale in the LSST Database},
+  Volume =       376,
+  Year =         2007
+}
+
+@inproceedings{2007ASPC..376..265S,
+  Adsnote =      {Provided by the SAO/NASA Astrophysics Data System},
+  Adsurl =       {http://adsabs.harvard.edu/abs/2007ASPC..376..265S},
+  Author =       {Scott, D. and Pierfederici, F. and Swaters, R. and
+                  Thomas, B. and Valdes, F.G.},
+  Booktitle =    {Astronomical Data Analysis Software and Systems XVI},
+  Date-Added =   {2008-07-07 13:56:54 -0700},
+  Date-Modified ={2011-03-03 13:28:16 -0700},
+  Editor =       {{Shaw}, R.~A. and {Hill}, F. and {Bell}, D.~J.},
+  Month =        oct,
+  Pages =        {265-+},
+  Series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  Title =        {The NOAO High-Performance Pipeline System:
+                  Architecture Overview},
+  Volume =       376,
+  Year =         2007
+}
+
+@inproceedings{2007IAUS..236..353I,
+  Adsnote =      {Provided by the SAO/NASA Astrophysics Data System},
+  Adsurl =       {http://adsabs.harvard.edu/abs/2007IAUS..236..353I},
+  Author =       {Ivezi{\'c}, {\v Z}. and Tyson, J.A. and Juri, M. and
+                  Kubica, J. and Connolly, A. and Pierfederici, F. and
+                  Harris, A.W. and Bowell, E. and Null, N.},
+  Booktitle =    {IAU Symposium},
+  Date-Added =   {2008-07-07 13:57:08 -0700},
+  Date-Modified ={2008-07-07 14:06:02 -0700},
+  Doi =          {10.1017/S1743921307003420},
+  Editor =       {{Valsecchi}, G.~B. and {Vokrouhlick{\'y}}, D.},
+  Pages =        {353-362},
+  Series =       {IAU Symposium},
+  Title =        {LSST: Comprehensive NEO detection, characterization,
+                  and orbits},
+  Volume =       236,
+  Year =         2007,
+  Bdsk-Url-1 =   {http://dx.doi.org/10.1017/S1743921307003420}
+}
+
+@article{2007PASP..119.1462B,
+  Adsnote =      {Provided by the SAO/NASA Astrophysics Data System},
+  Adsurl =       {http://adsabs.harvard.edu/abs/2007PASP..119.1462B},
+  Author =       {Becker, A. and Silvestri, N. and Owen, R. and
+                  Ivezi{\'c}, {\v Z}. and Lupton, R.},
+  Date-Added =   {2008-07-07 13:53:46 -0700},
+  Date-Modified ={2011-03-03 13:28:36 -0700},
+  Doi =          {10.1086/524710},
+  Eprint =       {arXiv:0712.0637},
+  Journal =      {\pasp},
+  Keywords =     {Data Analysis and Techniques},
+  Month =        dec,
+  Pages =        {1462-1482},
+  Title =        {In Pursuit of LSST Science Requirements: A
+                  Comparison of Photometry Algorithms},
+  Volume =       119,
+  Year =         2007,
+  Bdsk-Url-1 =   {http://dx.doi.org/10.1086/524710}
+}
+
+@misc{2008lim-mysql,
+  author =       {K.-T. Lim},
+  title =        {Astronomy, Petabytes, and MySQL},
+  note =         {MySQL Conference, Santa Clara, CA, April 16, 2008},
+  month =        apr,
+  year =         2008,
+  url =
+                  {http://conferences.oreilly.com/mysql2008/public/schedule/detail/849},
+}
+
+@misc{2008lim-hpc,
+  author =       {K.-T. Lim},
+  title =        {LSST and SciDB},
+  note =         {Stanford HPC Conference, Stanford, CA, USA, August
+                  28, 2008},
+  month =        aug,
+  year =         2008
+}
+
+@misc{2008lim-keck,
+  author =       {K.-T. Lim},
+  title =        {The LSST Data Management System},
+  note =         {Talk at Keck Observatory, December 2, 2008},
+  month =        dec,
+  year =         2008
+}
+
+@misc{2008lim-iplant,
+  author =       {K.-T. Lim},
+  title =        {Cyberinfrastructure Lessons from LSST Data
+                  Management},
+  note =         {iPlant Workshop (remote presentation), December 16,
+                  2008},
+  month =        dec,
+  year =         2008
+}
+
+@INPROCEEDINGS{2008AIPC.1082..347B,
+  author =       {{Borne}, K. and {Becla}, J. and {Davidson}, I. and
+                  {Szalay}, A. and {Tyson}, J.~A.},
+  title =        "{The LSST Data Mining Research Agenda}",
+  keywords =     {Astronomical catalogs atlases sky surveys databases
+                  retrieval systems archives etc., Data presentation
+                  and visualization: algorithms and implementation,
+                  Cosmology},
+  booktitle =    {American Institute of Physics Conference Series},
+  year =         2008,
+  series =       {American Institute of Physics Conference Series},
+  volume =       1082,
+  archivePrefix ="arXiv",
+  eprint =       {0811.0167},
+  editor =       {{Bailer-Jones}, C.~A.~L.},
+  month =        dec,
+  pages =        {347-351},
+  doi =          {10.1063/1.3059074},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008AIPC.1082..347B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2008AIPC.1082..359I,
+  author =       {{Ivezi{\'c}}, {\v Z}. and {Axelrod}, T. and
+                  {Becker}, A.~C. and {Becla}, J. and {Borne}, K. and
+                  {Burke}, D.~L. and {Claver}, C.~F. and {Cook},
+                  K.~H. and {Connolly}, A. and {Gilmore}, D.~K. and
+                  {Jones}, R.~L. and {Juri{\'c}}, M. and {Kahn},
+                  S.~M. and {Lim}, K.-T. and {Lupton}, R.~H. and
+                  {Monet}, D.~G. and {Pinto}, P.~A. and {Sesar},
+                  B. and {Stubbs}, C.~W. and {Tyson}, J.~A.},
+  title =        "{Parametrization and Classification of 20 Billion
+                  LSST Objects: Lessons from SDSS}",
+  keywords =     {Space-based ultraviolet optical and infrared
+                  telescopes, Quasars, active or peculiar galaxies
+                  objects and systems, Asteroids meteoroids},
+  booktitle =    {American Institute of Physics Conference Series},
+  year =         2008,
+  series =       {American Institute of Physics Conference Series},
+  volume =       1082,
+  archivePrefix ="arXiv",
+  eprint =       {0810.5155},
+  editor =       {{Bailer-Jones}, C.~A.~L.},
+  month =        dec,
+  pages =        {359-365},
+  doi =          {10.1063/1.3059076},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008AIPC.1082..359I},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Article{2008becla-dsj,
+  author =       {J. Becla and K-T Lim},
+  title =        {Report from the First Workshop on Extremely Large
+                  Databases},
+  journal =      {Data Science Journal},
+  year =         2008,
+  doi =          {10.2481/dsj.7.1},
+  volume =       7,
+  month =        feb,
+  abstract =     {Industrial and scientific datasets have been growing
+                  enormously in size and complexity in recent
+                  years. The largest transactional databases and data
+                  warehouses can no longer be hosted cost-effectively
+                  in off-the-shelf commercial database management
+                  systems. There are other forums for discussing
+                  databases and data warehouses, but they typically
+                  deal with problems occurring at smaller scales and
+                  do not always focus on practical solutions or
+                  influencing DBMS vendors. Given the relatively small
+                  (but highly influential and growing) number of users
+                  with these databases and the relatively small number
+                  of opportunities to exchange practical information
+                  related to DBMSes at extremely large scale, a
+                  workshop on extremely large databases was
+                  organized. This paper is the final report of the
+                  discussions and activities at the workshop.},
+}
+
+@Article{2008becla-dsj2,
+  author =       {J. Becla and K-T Lim},
+  title =        {Report from the SciDB Workshop},
+  journal =      {Data Science Journal},
+  year =         2008,
+  doi =          {10.2481/dsj.7.88},
+  volume =       7,
+  month =        sep,
+  abstract =     {A mini-workshop with representatives from the
+                  data-driven science and database research
+                  communities was organized in response to suggestions
+                  at the first XLDB Workshop. The goal was to develop
+                  common requirements and primitives for a
+                  next-generation database management system that
+                  scientists would use, including those from
+                  high-energy physics, astronomy, biology, geoscience
+                  and fusion, in order to stimulate research and
+                  advance technology. These requirements were thought
+                  by the database researchers to be novel and unlikely
+                  to be fully met by current commercial vendors. The
+                  two groups accordingly decided to explore building a
+                  new open source DBMS. This paper is the final report
+                  of the discussions and activities at the workshop.},
+}
+
+@INPROCEEDINGS{2008ASPC..394..114B,
+   author = {{Becla}, J. and {Lim}, K.-T. and {Monkewitz}, S. and {Nieto-Santisteban}, M. and
+	{Thakar}, A.},
+    title = "{Organizing the LSST Database for Real-Time Astronomical Processing}",
+booktitle = {Astronomical Data Analysis Software and Systems XVII},
+     year = 2008,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 394,
+   editor = {{Argyle}, R.~W. and {Bunclark}, P.~S. and {Lewis}, J.~R.},
+    month = aug,
+    pages = {114},
+   adsurl = {http://adsabs.harvard.edu/abs/2008ASPC..394..114B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2008ASPC..394..107T,
+  author =       {{Tyson}, J.~A. and {Roat}, C. and {Bosch}, J. and
+                  {Wittman}, D.  },
+  title =        "{LSST and the Dark Sector: Image Processing
+                  Challenges}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  XVII},
+  year =         2008,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       394,
+  archivePrefix ="arXiv",
+  eprint =       {0808.3425},
+  editor =       {{Argyle}, R.~W. and {Bunclark}, P.~S. and {Lewis},
+                  J.~R.},
+  month =        aug,
+  pages =        107,
+  adsurl =       {http://adsabs.harvard.edu/abs/2008ASPC..394..107T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@unpublished{2008kantor-pucon,
+  Author =       {Kantor, J.},
+  Date-Added =   {2008-07-07 13:58:36 -0700},
+  Date-Modified ={2008-07-07 14:06:47 -0700},
+  Note =         {PUC{\'O}N SYMPOSIUM 2008, Fifth AccessNova Forum:
+                  Ubiquitous Networks in Advanced Applications},
+  Title =        {LSST Processing: Challenges and Solutions},
+  Year =         2008
+}
+
+@unpublished{2008kantor-pucon2,
+  Author =       {Kantor, J.},
+  note =         {PUC{\'O}N SYMPOSIUM 2008, Fifth AccessNova Forum:
+                  Ubiquitous Networks in Advanced Applications},
+  Date-Added =   {2008-07-07 14:00:34 -0700},
+  Date-Modified ={2008-07-07 14:06:36 -0700},
+  Title =        {LSST Overview},
+  Year =         2008
+}
+
+@Unpublished{2008kantor-hawaii,
+  author =       {Jeff Kantor},
+  title =        {LSST Data Management: Making Peta-scale Data
+                  Accessible},
+  note =         {Talk at Institute for Astronomy, University of
+                  Hawaii, 19 June 2008},
+  month =        jun,
+  year =         2008,
+  url =
+                  {http://www.slideserve.com/rusty/jeff-kantor-lsst-data-management-systems-manager-lsst-corporation-institute-for-astronomy},
+}
+
+@article{2008Icar..195..474M,
+  Adsnote =      {Provided by the SAO/NASA Astrophysics Data System},
+  Adsurl =       {http://adsabs.harvard.edu/abs/2008Icar..195..474M},
+  Author =       {Milani, A. and Gronchi, G.and Farnocchia, D. and
+                  Ivezi{\'c}, {\v Z}. and Jedicke, R. and Denneau,
+                  L. and Pierfederici, F.},
+  Date-Added =   {2008-07-07 13:56:40 -0700},
+  Date-Modified ={2011-03-03 13:28:44 -0700},
+  Doi =          {10.1016/j.icarus.2007.11.033},
+  Journal =      {Icarus},
+  Month =        may,
+  Pages =        {474-492},
+  Title =        {Topocentric orbit determination: Algorithms for the
+                  next generation surveys},
+  Volume =       195,
+  Year =         2008,
+  Bdsk-Url-1 =   {http://dx.doi.org/10.1016/j.icarus.2007.11.033}
+}
+
+@unpublished{2008kantor-brazil,
+  Author =       {Kantor, J.},
+  note =         {New Astronomy: The Data Challenge, Rio de Janeiro,
+                  Brazil},
+  Date-Added =   {2008-07-07 14:01:01 -0700},
+  Date-Modified ={2008-07-07 14:06:21 -0700},
+  Title =        {LSST Data Management: Making Petascale Data
+                  Accessible},
+  Year =         2008,
+  month =        may,
+}
+
+@unpublished{2008kantor-brazil2,
+  Author =       {Kantor, J.},
+  note =         {Brazilian Symposium of Computer Networks and
+                  Distributed Systems},
+  Date-Added =   {2008-07-07 14:00:46 -0700},
+  Date-Modified ={2008-07-07 14:06:31 -0700},
+  Title =        {LSST Network Requirements},
+  Year =         2008
+}
+
+@INPROCEEDINGS{2009ASPC..411..106L,
+   author = {{Laher}, R.~R. and {Levine}, D. and {Mannings}, V. and {McGehee}, P. and
+	{Rho}, J. and {Shaw}, R. and {Kantor}, J.},
+    title = "{LSST Science Data Quality Analysis Subsystem Design}",
+booktitle = {Astronomical Data Analysis Software and Systems XVIII},
+     year = 2009,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 411,
+   editor = {{Bohlender}, D.~A. and {Durand}, D. and {Dowler}, P.},
+    month = sep,
+    pages = {106},
+   adsurl = {http://adsabs.harvard.edu/abs/2009ASPC..411..106L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@InProceedings{2009becla-cidr,
+  author =       {Michael Stonebraker and Jacek Becla and David Dewitt
+                  and Kian-Tat Lim and David Maier and Oliver
+                  Ratzesberger and Stan Zdonik},
+  title =        {Requirements for Science Data Bases and SciDB},
+  booktitle =    {Conference on Innovative Data Systems Research -
+                  CIDR},
+  year =         2009,
+  url =
+                  {http://www-db.cs.wisc.edu/cidr/cidr2009/Paper_26.pdf},
+  abstract =     {For the past year, we have been assembling
+                  requirements from a collection of scientific data
+                  base users from astronomy, particle physics, fusion,
+                  remote sensing, oceanography, and biology. The
+                  intent has been to specify a common set of
+                  requirements for a new science data base system,
+                  which we call SciDB. In addition, we have discovered
+                  that very complex business analytics share most of
+                  the same requirements as "big science". We have also
+                  constructed a partnership of companies to fund the
+                  development of SciDB, including eBay, the Large
+                  Synoptic Survey Telescope (LSST), Microsoft, the
+                  Stanford Linear Accelerator Center (SLAC) and
+                  Vertica. Lastly, we have identified two "lighthouse
+                  customers" (LSST and eBay) who will run the initial
+                  system, once it is constructed. In this paper, we
+                  report on the requirements we have identified and
+                  briefly sketch some of the SciDB design.},
+}
+
+@article{2009:Cudre-Mauroux:DSS:1687553.1687584,
+  author =       {Cudre-Mauroux, P. and Kimura, H. and Lim, K.-T. and
+                  Rogers, J. and Simakov, R. and Soroush, E. and
+                  Velikhov, P. and Wang, D. L. and Balazinska, M. and
+                  Becla, J. and DeWitt, D. and Heath, B. and Maier,
+                  D. and Madden, S. and Patel, J. and Stonebraker,
+                  M. and Zdonik, S.},
+  title =        {A Demonstration of SciDB: A Science-oriented DBMS},
+  journal =      {Proc. VLDB Endow.},
+  issue_date =   {August 2009},
+  volume =       2,
+  number =       2,
+  month =        aug,
+  year =         2009,
+  issn =         {2150-8097},
+  pages =        {1534--1537},
+  numpages =     4,
+  url =          {http://dx.doi.org/10.14778/1687553.1687584},
+  doi =          {10.14778/1687553.1687584},
+  acmid =        1687584,
+  publisher =    {VLDB Endowment},
+}
+
+@Unpublished{2009becla-sdcc,
+  author =       {Jacek Becla},
+  title =        {SciDB: Open Source Data Management System for
+                  Data-Intensive Scientific Analytics},
+  note =         {Talk at San Diego Supercomputer Center},
+  month =        jun,
+  year =         2009,
+  url =
+                  {http://www.slideshare.net/sdsc/scidb-open-source-data-management-system-for-dataintensive-scientific-analytics},
+}
+
+@INPROCEEDINGS{2009astro2010P...6B,
+  author =       {{Borne}, K. and {Accomazzi}, A. and {Bloom}, J. and
+                  {Brunner}, R. and {Burke}, D. and {Butler}, N. and
+                  {Chernoff}, D.~F. and {Connolly}, B. and {Connolly},
+                  A. and {Connors}, A. and {Cutler}, C. and {Desai},
+                  S. and {Djorgovski}, G. and {Feigelson}, E. and
+                  {Finn}, L.~S. and {Freeman}, P. and {Graham}, M. and
+                  {Gray}, N. and {Graziani}, C. and {Guinan},
+                  E.~F. and {Hakkila}, J. and {Jacoby}, S. and
+                  {Jefferys}, W. and {Kashyap} and {Kelly}, B. and
+                  {Knuth}, K. and {Lamb}, D.~Q. and {Lee}, H. and
+                  {Loredo}, T. and {Mahabal}, A. and {Mateo}, M. and
+                  {McCollum}, B. and {Muench}, A. and {Pesenson},
+                  M. and {Petrosian}, V. and {Primini}, F. and
+                  {Protopapas}, P. and {Ptak}, A. and {Quashnock},
+                  J. and {Raddick}, M.~J. and {Rocha}, G. and {Ross},
+                  N. and {Rottler}, L. and {Scargle}, J. and
+                  {Siemiginowska}, A. and {Song}, I. and {Szalay},
+                  A. and {Tyson}, J.~A. and {Vestrand}, T. and
+                  {Wallin}, J. and {Wandelt}, B. and {Wasserman},
+                  I.~M. and {Way}, M. and {Weinberg}, M. and {Zezas},
+                  A. and {Anderes}, E. and {Babu}, J. and {Becla},
+                  J. and {Berger}, J. and {Bickel}, P.~J. and {Clyde},
+                  M. and {Davidson}, I. and {van Dyk}, D. and
+                  {Eastman}, T. and {Efron}, B. and {Genovese}, C. and
+                  {Gray}, A. and {Jang}, W. and {Kolaczyk}, E.~D. and
+                  {Kubica}, J. and {Loh}, J.~M. and {Meng}, X.-L. and
+                  {Moore}, A. and {Morris}, R. and {Park}, T. and
+                  {Pike}, R. and {Rice}, J. and {Richards}, J. and
+                  {Ruppert}, D. and {Saito}, N. and {Schafer}, C. and
+                  {Stark}, P.~B. and {Stein}, M. and {Sun}, J. and
+                  {Wang}, D. and {Wang}, Z. and {Wasserman}, L. and
+                  {Wegman}, E.~J. and {Willett}, R. and {Wolpert},
+                  R. and {Woodroofe}, M.},
+  title =        "{Astroinformatics: A 21st Century Approach to
+                  Astronomy}",
+  booktitle =    {astro2010: The Astronomy and Astrophysics Decadal
+                  Survey},
+  year =         2009,
+  series =       {ArXiv Astrophysics e-prints},
+  volume =       2010,
+  archivePrefix ="arXiv",
+  eprint =       {0909.3892},
+  primaryClass = "astro-ph.IM",
+  pages =        {6P},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009astro2010P...6B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009astro2010P...7B,
+  author =       {{Borne}, K.~D. and {Jacoby}, S. and {Carney}, K. and
+                  {Connolly}, A. and {Eastman}, T. and {Raddick},
+                  M.~J. and {Wallin}, J. and {Becla}, J. and
+                  {Castelez}, M. and {Connors}, A. and {Hamilton},
+                  T. and {Lintott}, C. and {McCollum}, B. and {Fox},
+                  P. and {Mahabal}, A. and {Olsen}, J. and {Pesenson},
+                  M. and {Ptak}, A. and {Ross}, N. and {Schweitzer},
+                  A. and {Teays}, T. and {Way}, M. and {Wood-Vasey},
+                  M.},
+  title =        "{The Revolution in Astronomy Education: Data Science
+                  for the Masses}",
+  booktitle =    {astro2010: The Astronomy and Astrophysics Decadal
+                  Survey},
+  year =         2009,
+  series =       {ArXiv Astrophysics e-prints},
+  volume =       2010,
+  archivePrefix ="arXiv",
+  eprint =       {0909.3895},
+  primaryClass = "astro-ph.IM",
+  pages =        {7P},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009astro2010P...7B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009AAS...21346028B,
+  author =       {{Becker}, A.~C. and {Silvestri}, N. and {Owen},
+                  R. and {Connolly}, A. and {Lupton}, R. and
+                  {Axelrod}, T. and {LSST Collaboration}},
+  title =        "{Modeling Spatially Varying (De)Convolution Kernels
+                  for LSST Difference Imaging}",
+  booktitle =    {American Astronomical Society Meeting Abstracts
+                  \#213},
+  year =         2009,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       41,
+  month =        jan,
+  pages =        {\#460.28},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009AAS...21346028B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009AAS...21346030A,
+  author =       {{Axelrod}, T.~S. and {Becker}, A. and {Becla},
+                  J. and {Burke}, D. and {Connolly}, A. and {Cutri},
+                  R. and {Dubois-Felsmann}, G. and {Ivezic}, Z. and
+                  {Kantor}, J. and {Levine}, D. and {Lim}, K. and
+                  {Lupton}, R. and {Monet}, D. and {Owen}, R. and
+                  {Plante}, R. and {Silvestri}, N. and {Tyson},
+                  J.~A. and {Wittman}, D. and {LSST Collaboration} },
+  title =        "{Producing an LSST Data Release}",
+  booktitle =    {American Astronomical Society Meeting Abstracts
+                  \#213},
+  year =         2009,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       41,
+  month =        jan,
+  pages =        {\#460.30},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009AAS...21346030A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010AAS...21540123D,
+  author =       {{Dubois-Felsmann}, G.~P. and {Axelrod}, T. and
+                  {Becker}, A. and {Becla}, J. and {Burke}, D. and
+                  {Connolly}, A. and {Cutri}, R. and {Ivezic}, Z. and
+                  {Kantor}, J. and {Levine}, D. and {Lim}, K.~T. and
+                  {Lupton}, R. and {Monet}, D. and {Owen}, R. and
+                  {Plante}, R. and {Tyson}, J.~A. and {Wittman}, D.},
+  title =        "{Data Management R{\amp}D for the LSST Project}",
+  booktitle =    {American Astronomical Society Meeting Abstracts
+                  \#215},
+  year =         2010,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       42,
+  month =        jan,
+  pages =        {\#401.23},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010AAS...21540123D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010AAS...21540102C,
+  author =       {{Claver}, C.~F. and {Dubois-Felsmann}, G.~P. and
+                  {Delgado}, F. and {Hascall}, P. and {Horn}, D. and
+                  {Marshall}, S. and {Nordby}, M. and {Schalk},
+                  T.~L. and {Schumacher}, G. and {Sebag}, J. and {LSST
+                  Project Team} },
+  title =        "{The LSST: A System of Systems}",
+  booktitle =    {American Astronomical Society Meeting Abstracts
+                  \#215},
+  year =         2010,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       42,
+  month =        jan,
+  pages =        {\#401.02},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010AAS...21540102C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Article{2010becla-dsj,
+  author =       {Jacek Becla and Kian-Tat Lim and Daniel L. Wang},
+  title =        "{Report from the 3rd Workshop on Extremely Large
+                  Databases}",
+  journal =      {Data Science Journal},
+  year =         2010,
+  doi =          {10.2481/dsj.xldb09},
+  volume =       8,
+  pages =        {MR1--MR16},
+  month =        feb,
+  abstract =     {Academic and industrial users are increasingly
+                  facing the challenge of petabytes of data, but
+                  managing and analyzing such large data sets still
+                  remains a daunting task. Both the database and the
+                  map/reduce communities worldwide are working on
+                  addressing these issues. The 3rd Extremely Large
+                  Databases workshop was organized to examine the
+                  needs of scientific communities beginning to face
+                  these issues, to reach out to European communities
+                  working on extremely large scale data challenges,
+                  and to brainstorm possible solutions. The science
+                  benchmark that emerged from the 2nd workshop in this
+                  series was also debated. This paper is the final
+                  report of the discussions and activities at this
+                  workshop.}
+}
+
+@inproceedings{2010becla-adass,
+  Author =       {Jacek Becla},
+  Date-Added =   {2012-01-24 14:29:33 -0700},
+  Date-Modified ={2012-01-24 14:30:39 -0700},
+  Month =        {November},
+  Organization = {SLAC National Accelerator Laboratory},
+  Booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  Series =       {ADASS XX},
+  Title =        {LSST Database Architecture -- Preparing for the
+                  Extreme Scale Analytics},
+  Year =         2010
+}
+
+@Unpublished{2009pierfederici-htu,
+  author =       {Francesco Pierfederici},
+  title =        "{LSST-PanSTARRS Solar System Events}",
+  booktitle =    {Hot-Wiring the Transient Universe 2, Santa Cruz},
+  month =        apr,
+  year =         2009,
+  url =
+                  {http://www.cacr.caltech.edu/hotwired2/program/presentations/pierfederici.pdf},
+  abstract =     {The presentation will describe the system developed
+                  by LSST and PanSTARRS to generate and distribute
+                  Solar System VOEvents. It will describe
+                  architectural choices and lesson learned.},
+  note =         {Presented at Hot-Wiring the Transient Universe 2, Santa Cruz},
+}
+
+@Unpublished{2009jones-htu,
+  author =       {Lynne Jones},
+  title =        "{Fast Transients to Long Period Variables:
+                  Timescales in LSST}",
+  booktitle =    {Hot-Wiring the Transient Universe 2, Santa Cruz},
+  month =        apr,
+  year =         2009,
+  url =
+                  {http://www.cacr.caltech.edu/hotwired2/program/presentations/jones_hotwiring.pdf},
+  note =         {Presented at Hot-Wiring the Transient Universe 2, Santa Cruz},
+}
+
+@inproceedings{2010freemon-adass,
+  Author =       {D. Michael Freemon and J. Becla and Gregory
+                  P. Dubois-Felsmann and J. Kantor and K. T. Lim and
+                  R. Plante},
+  Date-Added =   {2012-01-24 14:26:49 -0700},
+  Date-Modified ={2012-01-24 14:30:50 -0700},
+  Month =        {November},
+  Organization = {LSST Corporation},
+  Booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  Title =        {LSST Data Management Infrastructure},
+  Year =         2010
+}
+
+@inproceedings{2010jagatheesan-ieee,
+  Author =       {Jeff Kantor and Arun Jagatheesan},
+  Date-Added =   {2012-01-24 14:35:21 -0700},
+  Date-Modified ={2012-01-24 14:36:26 -0700},
+  Month =        {May},
+  Organization = {LSST Corporation},
+  Publisher =    {IEEE},
+  Series =       {IEEE MSST2010},
+  Booktitle =    {26th IEEE (MSST2010) Symposium on Massive Storage Systems and Technologies},
+  Title =        {Storage Challenges for LSST: When Science Is Bigger
+                  Than Your Hardware},
+  url =          {http://storageconference.us/2010/Presentations/MSST/4.Kantor.pdf},
+  Year =         2010
+}
+
+@inproceedings{2010axelrod-sc,
+  Author =       {Tim Axelrod and Jeff Kantor},
+  Date-Added =   {2012-01-24 14:39:16 -0700},
+  Date-Modified ={2012-01-24 14:40:15 -0700},
+  Month =        {November},
+  Organization = {LSST Corporation},
+  Publisher =    {Supercomputing Conference},
+  Booktitle =    {Supercomputing 2010},
+  Title =        {Cyber-Infrastructure for the LSST Data Management
+                  System},
+  url =
+                  {https://docushare.lsstcorp.org/docushare/dsweb/Get/Document-10284/},
+  Year =         2010
+}
+
+@INPROCEEDINGS{2010SPIE.7737E..0VS,
+  author =       {{Smith}, R.~C. and {Seaman}, R. and {Kantor}, J. and
+                  {Axelrod}, T.  },
+  title =        "{Transient alert operations for the Large Synoptic
+                  Survey Telescope}",
+  booktitle =    {Observatory Operations: Strategies, Processes, and
+                  Systems III},
+  year =         2010,
+  editor =       {David R. Silva and Alison B. Peck and B. Thomas
+                  Soifer},
+  series =       {Proc.\ SPIE},
+  volume =       7737,
+  month =        jul,
+  eid =          {77370V},
+  pages =        0,
+  doi =          {10.1117/12.858322},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7737E..0VS},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7738E..0PS,
+  author =       {{Sweeney}, D. and {Claver}, C. and {Jacoby}, S. and
+                  {Kantor}, J. and {Krabbendam}, V. and {Kurita}, N.},
+  title =        "{Management evolution in the LSST project}",
+  booktitle =    {Modeling, Systems Engineering, and Project
+                  Management for Astronomy IV},
+  editor =       {George Z. Angeli and Philippe Dierickx},
+  year =         2010,
+  series =       {Proc.\ SPIE},
+  volume =       7738,
+  month =        jul,
+  eid =          {77380P},
+  pages =        0,
+  doi =          {10.1117/12.857301},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7738E..0PS},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7740E..0HS,
+  author =       {{Shaw}, R.~A. and {Levine}, D. and {Axelrod}, T. and
+                  {Laher}, R.~R. and {Mannings}, V.~G.},
+  title =        "{Science data quality assessment for the Large
+                  Synoptic Survey Telescope}",
+  booktitle =    {Software and Cyberinfrastructure for Astronomy},
+  editor =       {Nicole M. Radziwill and Alan Bridger},
+  year =         2010,
+  series =       {Proc.\ SPIE},
+  volume =       7740,
+  month =        jul,
+  eid =          {77400H},
+  pages =        0,
+  doi =          {10.1117/12.857293},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7740E..0HS},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7740E..15A,
+  author =       {{Axelrod}, T. and {Kantor}, J. and {Lupton},
+                  R.~H. and {Pierfederici}, F.  },
+  title =        "{An open source application framework for
+                  astronomical imaging pipelines}",
+  booktitle =    {Software and Cyberinfrastructure for Astronomy},
+  editor =       {Nicole M. Radziwill and Alan Bridger},
+  year =         2010,
+  series =       {Proc.\ SPIE},
+  volume =       7740,
+  month =        jul,
+  eid =          774015,
+  pages =        15,
+  doi =          {10.1117/12.857297},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7740E..15A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7740E..1HJ,
+  author =       {{Jagatheesan}, A.~S. and {Kantor}, J. and {Plante},
+                  R. and {Becla}, J. and {Freemon}, D.~M. and {Lim},
+                  K.-T. and {Wan}, M.},
+  title =        "{File-storage cyberinfrastructure for large-scale
+                  projects: years before first-light}",
+  booktitle =    {Software and Cyberinfrastructure for Astronomy},
+  editor =       {Nicole M. Radziwill and Alan Bridger},
+  year =         2010,
+  series =       {Proc.\ SPIE},
+  volume =       7740,
+  month =        jul,
+  eid =          {77401H},
+  pages =        1,
+  doi =          {10.1117/12.857812},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7740E..1HJ},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7740E..1NK,
+  author =       {{Kantor}, J. and {Axelrod}, T.},
+  title =        "{The Large Synoptic Survey Telescope data management
+                  overview}",
+  booktitle =    {Software and Cyberinfrastructure for Astronomy},
+  editor =       {Nicole M. Radziwill and Alan Bridger},
+  year =         2010,
+  series =       {Proc.\ SPIE},
+  volume =       7740,
+  month =        jul,
+  eid =          {77401N},
+  pages =        1,
+  doi =          {10.1117/12.857280},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7740E..1NK},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7740E..1OK,
+  author =       {{Kantor}, J.},
+  title =        "{The Large Synoptic Survey Telescope data
+                  challenges}",
+  booktitle =    {Software and Cyberinfrastructure for Astronomy},
+  editor =       {Nicole M. Radziwill and Alan Bridger},
+  year =         2010,
+  series =       {Proc.\ SPIE},
+  volume =       7740,
+  month =        jul,
+  eid =          {77401O},
+  pages =        1,
+  doi =          {10.1117/12.857253},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7740E..1OK},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@inproceedings{2011AAS...21725212B,
+  Adsnote =      {Provided by the SAO/NASA Astrophysics Data System},
+  Adsurl =       {http://adsabs.harvard.edu/abs/2011AAS...21725212B},
+  Author =       {Becker, A. C. and Bloom, J. S. and Walkowicz,
+                  L. M. and LSST Collaboration},
+  Booktitle =    {American Astronomical Society Meeting Abstracts
+                  \#217},
+  Date-Added =   {2012-01-24 13:54:08 -0700},
+  Date-Modified ={2012-01-24 14:01:23 -0700},
+  Month =        jan,
+  Pages =        {\#252.12},
+  Series =       {Bulletin of the American Astronomical Society},
+  Title =        {Exploring the Transient and Variable Universe with
+                  LSST},
+  Volume =       43,
+  Year =         2011
+}
+
+@misc{2011lim-fermilab,
+  author =       {K.-T. Lim},
+  title =        {LSST Applications and Middleware},
+  note =         {Talk at Fermilab, May 12, 2011},
+  month =        may,
+  year =         2011
+}
+
+@Misc{2011ivezic-slac-pub-14716,
+  author =       {Z. Ivezic and others},
+  title =        {Parametrization and Classification of 20 Billion
+                  LSST Objects: Lessons from SDSS},
+  howpublished = {SLAC-PUB-14716},
+  month =        nov,
+  year =         2011,
+  url =          {http://www.osti.gov/scitech/biblio/1029150/},
+  note =         {Republished version of 2008AIPC.1082..359I},
+}
+
+@inproceedings{2011:Myers:SRM:2016741.2016750,
+  author =       {Myers, Jonathan A. and Tatineni, Mahidhar and
+                  Sinkovits, Robert S.},
+  title =        {Subset Removal on Massive Data with Dash},
+  booktitle =    {Proceedings of the 2011 TeraGrid Conference: Extreme
+                  Digital Discovery},
+  series =       {TG '11},
+  year =         2011,
+  isbn =         {978-1-4503-0888-5},
+  location =     {Salt Lake City, Utah},
+  pages =        {8:1--8:4},
+  articleno =    8,
+  numpages =     4,
+  url =          {http://doi.acm.org/10.1145/2016741.2016750},
+  doi =          {10.1145/2016741.2016750},
+  acmid =        2016750,
+  publisher =    {ACM},
+  address =      {New York, NY, USA},
+}
+
+@inproceedings{2011Wang:2011:QDS:2063348.2063364,
+  Acmid =        2063364,
+  Address =      {New York, NY, USA},
+  Articleno =    12,
+  Author =       {Wang, Daniel L. and Monkewitz, Serge M. and Lim,
+                  Kian-Tat and Becla, Jacek},
+  Booktitle =    {State of the Practice Reports},
+  Doi =          {http://doi.acm.org/10.1145/2063348.2063364},
+  Isbn =         {978-1-4503-1139-7},
+  Keywords =     {MPP, database, distributed, file system, parallel,
+                  shared-nothing},
+  Location =     {Seattle, Washington},
+  Numpages =     11,
+  Pages =        {12:1--12:11},
+  Publisher =    {ACM},
+  Series =       {SC '11},
+  Title =        {Qserv: a distributed shared-nothing database for the
+                  LSST catalog},
+  Url =          {http://doi.acm.org/10.1145/2063348.2063364},
+  Year =         2011,
+  Bdsk-Url-1 =   {http://doi.acm.org/10.1145/2063348.2063364}
+}
+
+@inproceedings{2011gibson-stsci,
+  Author =       {Robert Gibson},
+  Date-Added =   {2012-01-24 14:18:05 -0700},
+  Date-Modified ={2012-01-24 14:21:38 -0700},
+  Month =        jun,
+  Organization = {University of Washington},
+  Publisher =    {Space Telescope Science Institute},
+  Title =        {AGN Variability and Long-Term Monitoring},
+  booktitle =    {Very Wide Field Surveys in the Light of Astro2010},
+  Year =         2011,
+  Bdsk-Url-1 =
+                  {http://www.stsci.edu/institute/conference/verywidefield/}
+}
+
+@INPROCEEDINGS{2011ASPC..442..329G,
+  author =       {{Gibson}, R.~R. and {Ahmad}, Z. and {Bankert},
+                  J. and {Bard}, D. and {Connolly}, A.~J. and {Chang},
+                  C. and {Gilmore}, K. and {Grace}, E. and {Hannel},
+                  M. and {Jernigan}, J.~G. and {Jones}, L. and {Kahn},
+                  S.~M. and {Krughoff}, K.~S. and {Lorenz}, S. and
+                  {Marshall}, S. and {Nagarajan}, S. and {Peterson},
+                  J.~R. and {Pizagno}, J. and {Rasmussen}, A.~P. and
+                  {Shmakova}, M. and {Silvestri}, N. and {Todd},
+                  N. and {Young}, M.  },
+  title =        "{A Framework for End to End Simulations of the Large
+                  Synoptic Survey Telescope}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  year =         2011,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       442,
+  editor =       {{Evans}, I.~N. and {Accomazzi}, A. and {Mink},
+                  D.~J. and {Rots}, A.~H.  },
+  month =        jul,
+  pages =        329,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..329G},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@inproceedings{2012AAS...21915603S,
+  Adsnote =      {Provided by the SAO/NASA Astrophysics Data System},
+  Adsurl =       {http://adsabs.harvard.edu/abs/2012AAS...21915603S},
+  Author =       {{Shaw}, R. and {Axelrod}, T. and {Becker}, A.~C. and
+                  {Bickerton}, S. and {Juric}, M. and {Kantor}, J. and
+                  {Krughoff}, S. and {Lupton}, R.~H. and {Van Dyk},
+                  S. and {Data Management}, L. and {Simulations
+                  Teams}},
+  Booktitle =    {American Astronomical Society Meeting Abstracts},
+  Date-Modified ={2012-01-25 10:41:17 -0700},
+  Month =        jan,
+  Pages =        {\#156.03},
+  Series =       {American Astronomical Society Meeting Abstracts},
+  Title =        {{LSST Data Products and User Interfaces}},
+  Volume =       219,
+  Year =         2012
+}
+
+@inproceedings{2012AAS...21915607J,
+author = {{Juric}, M. and {Monet}, D. and {Gizis}, J.~E. and {Sesar}, B. and
+{Willman}, B. and {Geha}, M. and {Fadley}, R. and {Krughoff}, K.~S. and
+{Gibson}, R.~R. and {Connolly}, A.~J. and {Lupton}, R.~H. and
+{Peterson}, J.~R. and {Jernigan}, G.~J. and {Silvestri}, N.~M. and
+{LSST Data Management Team} and {LSST Image Simulation Team}
+},
+ title = "{End-to-end Tests of LSST Science Cases with Image Simulations: Rare Astrometric Targets and Ultra-faint Dwarf Galaxies}",
+booktitle = {American Astronomical Society Meeting Abstracts \#219},
+  year = 2012,
+series = {American Astronomical Society Meeting Abstracts},
+volume = 219,
+ month = jan,
+   eid = {156.07},
+ pages = {156.07},
+adsurl = {http://adsabs.harvard.edu/abs/2012AAS...21915607J},
+adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@misc{2012lim-aas,
+  author =       {K.-T. Lim},
+  title =        {The LSST Database: What to Expect},
+  note =         {AAS Splinter Meeting, Austin TX, January 8, 2012},
+  month =        jan,
+  year =         2012
+}
+
+@Misc{2012becla-xldb,
+  author =       {Jacek Becla and Kian-Tat Lim and Daniel L Wang},
+  title =        {Facts About XLDB-2011},
+  booktitle =    {5th Extremely Large Databases Conference and
+                  Invitational Workshop},
+  url =          {http://www.osti.gov/scitech/biblio/1035489/},
+  month =        feb,
+  year =         2012,
+  abstract =     {This note provides details of the 5th Extremely
+                  Large Databases Conference and Invitational Workshop
+                  that were held in 2011 on 18-19 October and 20
+                  October, respectively, at the SLAC National
+                  Accelerator Laboratory in Menlo Park,
+                  California. The main goals of the conference were:
+                  (1) Encourage and accelerate the exchange of ideas
+                  between users trying to build extremely large
+                  databases worldwide and database solution providers;
+                  (2) Share lessons, trends, innovations, and
+                  challenges related to building extremely large
+                  databases; (3) Facilitate the development and growth
+                  of practical technologies for extremely large
+                  databases; and (4) Strengthen, expand, and engage
+                  the XLDB community.},
+}
+
+@Unpublished{2012lim-xldbasia,
+  author =       {K.-T. Lim},
+  title =        {XLDB and the Large Synoptic Survey Telescope},
+  note =         {XLDB Asia, Beijing, China, June 22-23 2012 },
+  month =        jun,
+  year =         2012,
+  url =          {http://idke.ruc.edu.cn/xldb/www.xldb-asia.org/slides/XLDB\%20Asia\%20-\%20LSST.pdf},
+}
+
+@INPROCEEDINGS{2012SPIE.8448E..0PG,
+  author =       {{Graham}, M.~J. and {Djorgovski}, S.~G. and
+                  {Donalek}, C. and {Drake}, A.~J. and {Mahabal},
+                  A.~A. and {Plante}, R.~L. and {Kantor}, J. and
+                  {Good}, J.~C.},
+  title =        "{Connecting the time domain community with the
+                  Virtual Astronomical Observatory}",
+  booktitle =    {Observatory Operations: Strategies, Processes, and
+                  Systems IV},
+  editor =       {Alison B. Peck and Robert L. Seaman and Fernando
+                  Comeron},
+  year =         2012,
+  series =       {Proc.\ SPIE},
+  volume =       8448,
+  archivePrefix ="arXiv",
+  eprint =       {1206.4035},
+  primaryClass = "astro-ph.IM",
+  month =        sep,
+  eid =          {84480P},
+  pages =        0,
+  doi =          {10.1117/12.926577},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8448E..0PG},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8449E..0NK,
+  author =       {{Kantor}, J.~P.},
+  title =        "{The Large Synoptic Survey Telescope project
+                  management control system}",
+  booktitle =    {Modeling, Systems Engineering, and Project
+                  Management for Astronomy V},
+  editor =       {George Z. Angeli and Philippe Dierickx},
+  year =         2012,
+  series =       {Proc.\ SPIE},
+  volume =       8449,
+  month =        sep,
+  eid =          {84490N},
+  pages =        0,
+  doi =          {10.1117/12.924887},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8449E..0NK},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8451E..0VF,
+  author =       {{Freemon}, D.~M. and {Lim}, K.-T. and {Becla},
+                  J. and {Dubois-Felsman}, G.~P. and {Kantor}, J.},
+  title =        "{Data management cyberinfrastructure for the Large
+                  Synoptic Survey Telescope}",
+  booktitle =    {Software and Cyberinfrastructure for Astronomy II},
+  editor =       {Nicole M. Radziwill and Gianluca Chiozzi},
+  year =         2012,
+  series =       {Proc.\ SPIE},
+  volume =       8451,
+  month =        sep,
+  eid =          {84510V},
+  pages =        0,
+  doi =          {10.1117/12.926596},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8451E..0VF},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Unpublished{2012juric-illinois,
+  author =       {Mario Juric},
+  title =        {Large Synoptic Survey Telescope: The Era of
+                  Petascale Survey Astronomy},
+  note =         {Astrophysics colloquium at University of Illinois,
+                  9/11/2012},
+  month =        sep,
+  year =         2012,
+  url =
+                  {http://physics.illinois.edu/events/detail.asp?id=23401858&startDate=9/11/2012},
+  abstract =     {The Large Synoptic Survey Telescope (LSST;
+                  http://lsst.org) is a planned, large-aperture,
+                  wide-field, ground-based telescope that will survey
+                  half the sky every few nights in six optical bands
+                  from 320 to 1050 nm. It will explore a wide range of
+                  astrophysical questions, ranging from discovering
+                  'killer' asteroids, to examining the nature of dark
+                  energy.  LSST will produce on average 15 terabytes
+                  of data per night, yielding a reduced data set of
+                  over 100 petabytes at the end of its 10-year
+                  mission. Dedicated HPC facilities (at NCSA) will
+                  process the images in near real time, with
+                  full-dataset reprocessing occurring on annual
+                  scale. A sophisticated data management system (DMS)
+                  will enable database queries from individual users,
+                  as well as computationally intensive scientific
+                  investigations that utilize the entire data set.
+                  LSST will be the first optical survey delivering
+                  petabyte-sized catalogs. Creating and mining those
+                  catalogs presents the community with significant
+                  challenges, as well as opportunities. In this
+                  colloquium I will present the science expected from
+                  LSST, the technology needed to achieve it, and
+                  provide an update of project status.}
+}
+
+@INPROCEEDINGS{2013AAS...22124701J,
+  author =       {{Juric}, M. and {Kantor}, J. and {Axelrod},
+                  T.~S. and {Dubois-Felsmann}, G.~P. and {Becla},
+                  J. and {Lim}, K. and {LSST Collaboration} and {LSST
+                  Science Collaborations} },
+  title =        "{LSST Data Products: Enabling LSST Science}",
+  booktitle =    {American Astronomical Society Meeting Abstracts
+                  \#221},
+  year =         2013,
+  series =       {American Astronomical Society Meeting Abstracts},
+  volume =       221,
+  month =        jan,
+  pages =        {\#247.01},
+  adsurl =       {http://adsabs.harvard.edu/abs/2013AAS...22124701J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2013AAS...22115202A,
+  author =       {{AlSayyad}, Y. and {Connolly}, A.~J. and {Becker},
+                  A.~C. and {Krughoff}, K.~S. and {Owen}, R.~E. and
+                  {Lupton}, R. and {LSST Data Management Team} },
+  title =        "{A Deeper Look at SDSS Stripe 82 Imaging: Galaxy
+                  Clustering in LSST Reprocessed Co-adds}",
+  booktitle =    {American Astronomical Society Meeting Abstracts
+                  \#221},
+  year =         2013,
+  series =       {American Astronomical Society Meeting Abstracts},
+  volume =       221,
+  month =        jan,
+  pages =        {\#152.02},
+  adsurl =       {http://adsabs.harvard.edu/abs/2013AAS...22115202A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013arXiv1303.7467F,
+  author =       {{Freemon}, D.~M.},
+  title =        "{Optimizing Throughput on Guaranteed-Bandwidth WAN
+                  Networks for the Large Synoptic Survey Telescope
+                  (LSST)}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1303.7467},
+  primaryClass = "cs.NI",
+  keywords =     {Computer Science - Networking and Internet
+                  Architecture},
+  year =         2013,
+  month =        mar,
+  adsurl =       {http://adsabs.harvard.edu/abs/2013arXiv1303.7467F},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Unpublished{2013juric-radiolsst,
+  author =       {Mario Juric},
+  title =        "{LSST Data Management Entering the Era of Petascale
+                  Optical Astronomy}",
+  note =         {Radio Astronomy in the LSST Era - Charlottesville,
+                  VA - May 6-8, 2013},
+  month =        may,
+  year =         2013,
+  abstract =     {The Large Synoptic Survey Telescope (LSST;
+                  http://lsst.org) is a planned, large-aperture,
+                  widefield, ground-based telescope that will survey
+                  half the sky every few nights in six optical bands
+                  from 320 to 1050 nm. It will explore a wide range of
+                  astrophysical questions, ranging from discovering
+                  killer asteroids, to examining the nature of dark
+                  energy. LSST will produce on average 15 terabytes of
+                  data per night, yielding an (uncompressed) reduced
+                  data set of 200 petabytes at the end of its 10-year
+                  mission. Dedicated HPC facilities (with a total of
+                  320 TFLOPS at start, scaling up to 1.7 PFLOPS by the
+                  end) will process the image data in near real time,
+                  with full-dataset reprocessings occurring on annual
+                  scale. A sophisticated data management system (DMS)
+                  will enable database queries from individual users,
+                  as well as computationally intensive scientific
+                  investigations that utilize the entire data set. The
+                  nature, quality, and volume of LSST data will be
+                  unprecedented in optical/IR astronomy, so the DMS
+                  design features petascale storage, terascale
+                  computing, and gigascale communications. LSST will
+                  be the first optical survey delivering
+                  petabyte-sized catalogs. Creating and mining those
+                  catalogs presents the community with significant
+                  challenges, as well as opportunities. I will discuss
+                  the DM system, the data products needed to achieve
+                  LSST’s science goals, the algorithms and technology
+                  being put in place to generate them, and report on
+                  DM’s progress as we prepare for Construction.},
+  url =
+                  {http://www.slideserve.com/daphne/lsst-survey-data-products-mario-juric-lsst-data-management-project-scientist-radio-astronomy-in-the-lsst-era-nrao-may-6-8-th-2013},
+}
+
+@Unpublished{2013juric-ivoa,
+  author =       {Mario Juric},
+  title =        "{LSST: Introduction and Data Management
+                  Requirements}",
+  note =         {Presented at the IVOA Interoperability Meeting,
+                  Heidelberg, Germany},
+  url =
+                  {http://wiki.ivoa.net/internal/IVOA/InterOpMay2013/juric.pdf},
+  month =        may,
+  year =         2013,
+}
+
+@Unpublished{2013juric-lssteurope,
+  author =       {Mario Juric},
+  title =        "{Enabling LSST Science: LSST Data Products}",
+  note =         {LSST@Europe: The Path to Science, Cambridge},
+  month =        sep,
+  year =         2013,
+  url =
+                  {https://project.lsst.org/meetings/lsst-europe-2013/sites/default/files/lsstcam13-juric.pdf},
+}
+
+@Unpublished{2013juric-nwu,
+  author =       {Mario Juric},
+  title =        "{LSST: Entering the Era of Petascale Astronomy}",
+  note =         {Northwestern University CIERA Interdisciplinary
+                  Colloquium, 12 November 2013},
+  month =        nov,
+  year =         2013,
+  url =
+                  {http://research.majuric.org/wp/wp-content/uploads/2013/11/LSST-Northwestern-Final.pdf},
+}
+
+@Unpublished{2014juric-jhu,
+  author =       {Mario Juric},
+  title =        "{Mapping the Milky Way with Large Surveys}",
+  note =         {Johns Hopkins Astronomy Colloquium, 25 February
+                  2014},
+  month =        feb,
+  year =         2014,
+  url =
+                  {http://research.majuric.org/wp/wp-content/uploads/2013/11/MW-JHU-Final.pdf},
+}
+
+@Unpublished{2014juric-stsci,
+  author =       {Mario Juric},
+  title =        "{Large Synoptic Survey Telescope: Entering the Era
+                  of Petascale Optical Astronomy}",
+  note =         {Space Telescope Science Institute Colloquium, 4
+                  February 2014},
+  month =        feb,
+  year =         2014,
+  url =
+                  {http://research.majuric.org/wp/wp-content/uploads/2013/11/LSST-STScI-20140204-Final.pdf},
+}
+
+@ARTICLE{2014PASP..126..196L,
+  author =       {{Lazio}, J.~W. and {Kimball}, A. and {Barger},
+                  A.~J. and {Brandt}, W.~N. and {Chatterjee}, S. and
+                  {Clarke}, T.~E. and {Condon}, J.~J. and {Dickman},
+                  R.~L. and {Hunyh}, M.~T. and {Jarvis}, M.~J. and
+                  {Juri{\'c}}, M. and {Kassim}, N.~E. and {Myers},
+                  S.~T. and {Nissanke}, S. and {Osten}, R. and
+                  {Zauderer}, B.~A.},
+  title =        "{Radio Astronomy in LSST Era}",
+  journal =      {\pasp},
+  archivePrefix ="arXiv",
+  eprint =       {1401.0716},
+  primaryClass = "astro-ph.IM",
+  year =         2014,
+  month =        feb,
+  volume =       126,
+  pages =        {196-209},
+  doi =          {10.1086/675262},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014PASP..126..196L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014era..conf30303B,
+  author =       {{Becla}, J. and {Wang}, D.~L.},
+  title =        "{Enabling Scalable Data Analytics for LSST and
+                  Beyond}",
+  booktitle =    {Exascale Radio Astronomy},
+  year =         2014,
+  volume =       2,
+  month =        apr,
+  adsurl =       {http://adsabs.harvard.edu/abs/2014era..conf30303B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014arXiv1410.1939F,
+  author =       {{Freemon}, D.~M.},
+  title =        "{Maximizing Utilization and Performance of
+                  Guaranteed-Bandwidth Long Fat Networks and Virtual
+                  Circuits}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1410.1939},
+  primaryClass = "cs.NI",
+  keywords =     {Computer Science - Networking and Internet
+                  Architecture},
+  year =         2014,
+  month =        oct,
+  adsurl =       {http://adsabs.harvard.edu/abs/2014arXiv1410.1939F},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014htu..conf...19K,
+  author =       {{Kantor}, J.},
+  title =        "{Transient Alerts in LSST}",
+  booktitle =    {The Third Hot-wiring the Transient Universe
+                  Workshop},
+  year =         2014,
+  editor =       {{Wozniak}, P.~R. and {Graham}, M.~J. and {Mahabal},
+                  A.~A. and {Seaman}, R.},
+  pages =        {19-26},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014htu..conf...19K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Unpublished{2014juric-gaiacal,
+  author =       {Mario Juric},
+  title =        "{Creating and Calibrating LSST Data Products}",
+  note =         {Presented at Astrophysical calibration of Gaia and other surveys,
+                  Ringberg Castle},
+  url =
+                  {http://www.slideshare.net/MarioJuric/gaiacal2014-talk-creating-and-calibrating-lsst-data-product},
+  month =        jul,
+  year =         2014,
+}
+
+@Unpublished{2014becker-astroinformatics,
+  author =       {Andrew Becker},
+  title =        "{Flexible and Scalable Methods for Time-Series
+                  Characterization}",
+  note =         {Astroinformatics 2014, Chile},
+  month =        aug,
+  year =         2014,
+  url =
+                  {http://eventos.cmm.uchile.cl/astro2014/wp-content/uploads/sites/13/2014/06/Astroinformatics2014.pdf},
+}
+
+@INPROCEEDINGS{2014becla-adass,
+  author =       {J. Becla},
+  title =        "{Enabling Scalable Data Analytics for LSST and
+                  Beyond Through Qserv}",
+  booktitle =    {Astronomical Data Analysis Software an Systems XXIV
+                  (ADASS XXIV)},
+  year =         2014,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  editor =       {{Taylor}, A.~R. and {Rosolowsky}, E.},
+  month =        nov,
+  abstract =     {The construction of the Large Synoptic Survey
+                  Telescope (LSST) is starting this year. Its large
+                  and rich data set will enable exploration of a wide
+                  range of astrophysical questions, ranging from
+                  discovering "killer" asteroids, to examining the
+                  nature of dark energy. The exploration will involve
+                  running a wide range of spatial and temporal
+                  analyses, including computationally intensive
+                  scientific investigations in multi-dimensional space
+                  over the entire data set. Over a million analyses,
+                  from trivial to very complex, are expected daily,
+                  every day, for decades. A specialized database
+                  system is developed to make that not only possible,
+                  but also fast and efficient. The talk will describe
+                  the driving requirements, assumptions made, and
+                  design trade offs that were considered in developing
+                  the baseline architecture for the LSST
+                  database. Details of its prototype implementation,
+                  Qserv, will be given, highlighting its features,
+                  status, and potential for usage outside LSST and
+                  even outside astronomy.}
+}
+
+@INPROCEEDINGS{2014economou-adass,
+  author =       {F. Economou},
+  title =        "{How should astronomy pay for software?}",
+  booktitle =    {Astronomical Data Analysis Software an Systems XXIV
+                  (ADASS XXIV)},
+  year =         2014,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  editor =       {{Taylor}, A.~R. and {Rosolowsky}, E.},
+  month =        nov,
+  abstract =     {Software engineering is more embedded in the
+                  astronomical data flow than ever before. In the last
+                  few decades we have seen a transition from
+                  institution-backed software funding (eg. IRAF,
+                  Starlink) to grant-backed funding at University
+                  research groups. Is this polycosm resulting in a
+                  Darwinian triumph of fitter ideas, or is it a
+                  constant re-invention of the wheel that is stopping
+                  us from making cumulative progress as a field? Is
+                  there a benefit to retaining long-term software
+                  engineering talent, and if so, can this be done on
+                  the grant system? Is it a good idea to have our
+                  software written by postdocs? By contractors? How do
+                  we compete in the free market for tech talent? Are
+                  open-source inspired initiatives (eg. AstroPy) a
+                  solution? How does the funding model for astronomy
+                  software impact the code produced, and can anybody
+                  be made to care?}
+}
+
+@Unpublished{2014krughoff-ztf,
+  author =       {K. Simon Krughoff},
+  title =        {Image Differencing for LSST},
+  note =         {ZTF-LSST Joint Meeting November 12th 2014},
+  url =          {http://dx.doi.org/10.5281/zenodo.45300},
+  doi =          {10.5281/zenodo.45300},
+  month =        nov,
+  year =         2014,
+}
+
+@Unpublished{2014juric-cfa,
+  author =       {Mario Juric},
+  title =        "{LSST/DM: Building a Next Generation Survey Data
+                  Processing System}",
+  note =         {A presentation about LSST Data Management delivered
+                  at Harvard-Smithsonian CfA Code Coffee.},
+  url =
+                  {http://www.slideshare.net/MarioJuric/lsstdm-building-a-next-generation-survey-data-processing-system},
+  month =        dec,
+  year =         2014,
+}
+
+@misc{2014lim-desc,
+  author =       {K.-T. Lim},
+  title =        {A Quick Tour of the LSST Software Stack},
+  note =         {Talk at DES-LSST Workshop, Fermilab, March 25, 2014},
+  month =        mar,
+  year =         2014,
+  url =
+                  {https://indico.fnal.gov/contributionDisplay.py?contribId=52&confId=7946},
+}
+
+@misc{2014lim-xldb,
+  author =       {K.-T. Lim},
+  title =        {The Designs for LSST's Extremely Large Databases},
+  note =         {XLDB South America 2014, Rio de Janeiro, Brazil,
+                  June 4, 2014},
+  month =        jun,
+  year =         2014,
+  url =          {http://xldb-rio2014.linea.gov.br/abstract/#ktlim},
+}
+
+@INPROCEEDINGS{2015htu..conf.....K,
+  author =       {Karl Simon Krughoff},
+  title =        "{LSST: The Alert Production Pipeline}",
+  booktitle =    {The Fourth Hot-wiring the Transient Universe
+                  Workshop, Santa Barbara},
+  year =         2015,
+  month =        may,
+  doi =          {http://dx.doi.org/10.5281/zenodo.45300},
+  url =
+                  {http://lcogt.net/files/media/Krughoff_Hotwiring-2015-final.pptx}
+}
+
+
+@Unpublished{2015swinbank-ivoa,
+  author =       {{Swinbank}, J.D.},
+  title =        "{LSST: Introduction and Data Management
+                  Requirements}",
+  note =         {Presented at the IVOA Interoperability Meeting,
+                  Sesto, Italy},
+  url =
+                  {http://wiki.ivoa.net/internal/IVOA/InterOpJune2015MCD/2015-06_-_LSST_at_IVOA_InterOp.pdf},
+  month =        jun,
+  year =         2015
+}
+
+@INPROCEEDINGS{2015ASPC..495..137G,
+  author =       {{Goldina}, T. and {Roby}, W. and {Wu}, X. and {Ly},
+                  L.},
+  title =        "{Web-based 2-d Visualization with Large Datasets}",
+  booktitle =    {Astronomical Data Analysis Software an Systems XXIV
+                  (ADASS XXIV)},
+  year =         2015,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       495,
+  editor =       {{Taylor}, A.~R. and {Rosolowsky}, E.},
+  month =        sep,
+  pages =        137,
+  adsurl =       {http://adsabs.harvard.edu/abs/2015ASPC..495..137G},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2015ASPC..495..417R,
+  author =       {{Roby}, W. and {Wu}, X. and {Ly}, L. and {Goldina},
+                  T.},
+  title =        "{Next Generation Search Interfaces}",
+  booktitle =    {Astronomical Data Analysis Software an Systems XXIV
+                  (ADASS XXIV)},
+  year =         2015,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       495,
+  editor =       {{Taylor}, A.~R. and {Rosolowsky}, E.},
+  month =        sep,
+  pages =        417,
+  adsurl =       {http://adsabs.harvard.edu/abs/2015ASPC..495..417R},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2015AAS...22543406W,
+  author =       {{Wu}, X. and {Roby}, W. and {Goldina}, T. and {Ly},
+                  L. and {IRSA IPAC} },
+  title =        "{IPAC Firefly package goes open source}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2015,
+  series =       {American Astronomical Society Meeting Abstracts},
+  volume =       225,
+  month =        jan,
+  pages =        {\#434.06},
+  adsurl =       {http://adsabs.harvard.edu/abs/2015AAS...22543406W},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@misc{2015lim-hpc,
+  author =       {K.-T. Lim},
+  title =        {Astroparticle physics: An LSST perspective},
+  note =         {HEP Software Foundation Workshop, SLAC National
+                  Accelerator Lab, January 20, 2015},
+  month =        jan,
+  year =         2015,
+  url =
+                  {http://indico.cern.ch/event/357737/session/3/contribution/16/attachments/712039/977483/HEPSWF_Meeting.pdf},
+}
+
+@ARTICLE{2015HiA....16..675J,
+  author =       {{Juric}, M. and {Tyson}, T.},
+  title =        "{LSST Data Management: Entering the Era of Petascale
+                  Optical Astronomy}",
+  journal =      {Highlights of Astronomy},
+  year =         2015,
+  month =        mar,
+  volume =       16,
+  pages =        {675-676},
+  doi =          {10.1017/S174392131401285X},
+  adsurl =       {http://adsabs.harvard.edu/abs/2015HiA....16..675J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Unpublished{2015alsayyad-noao,
+  author =       {Yusra AlSayyad and Ian McGreer and Andy Connolly and
+                  Xiaohui Fan and Zeljko Ivezic and Andy Becker and
+                  Mario Juric and {The LSST Data Management team}},
+  title =        {Case study: Classifying High Redshift Quasars on the
+                  LSST-Reprocessed SDSS Stripe 82 Imaging},
+  note =        {Presented at Tools for Astronomical Big Data, Tucson, AZ},
+  month =        mar,
+  year =         2015,
+  url =
+                  {http://www.noao.edu/meetings/bigdata/files/AlSayyad.pdf},
+  abstract =     {To evaluate methods for extracting information from
+                  multi-epoch imaging, the LSST data management team
+                  is testing the prototype pipeline, which converts
+                  pixels into catalogs, on simulated images and
+                  existing time domain surveys. A 250
+                  sq. deg. repeatedly-imaged stripe of the SDSS called
+                  Stripe 82 provides a strong test dataset because it
+                  was obtained under skies with highly variable
+                  conditions. Reprocessing the 20TB of imaging
+                  consisted of detecting sources on i-band co-adds but
+                  measuring flux on the single-epoch (ugriz) images,
+                  generating complete and less biased lightcurves for
+                  sources fainter than the single-epoch detection
+                  threshold. I will describe the technical challenges
+                  of aggregating these 16 billion photometry
+                  measurements into lightcurve metrics for each of the
+                  40 million objects. I will also discuss our
+                  application of ensemble classifiers to this dataset
+                  to select z~4 quasars with care to maintain the
+                  ability to estimate the completeness of the sample
+                  when the underlying population has a complex
+                  distribution in feature space.},
+}
+
+@Unpublished{2015becla-noao,
+  author =       {Jacek Becla},
+  title =        {Enabling Scalable Data Analytics for LSST and Beyond
+                  through Qserv},
+  note =        {Presented at Tools for Astronomical Big Data, Tucson, AZ},
+  month =        mar,
+  year =         2015,
+  url =
+                  {http://www.noao.edu/meetings/bigdata/files/becla.pdf},
+  abstract =     {The construction of the Large Synoptic Survey
+                  Telescope (LSST) is starting this year. Its large
+                  and rich data set will enable exploration of a wide
+                  range of astrophysical questions, ranging from
+                  discovering “killer” asteroids, to examining the
+                  nature of dark energy. The exploration will involve
+                  running a wide range of spatial and temporal
+                  analyses, including computationally intensive
+                  scientific investigations in multi-dimensional space
+                  over the entire data set. Over a million analyses,
+                  from trivial to very complex, are expected daily,
+                  every day, for decades. A specialized database
+                  system is developed to make that not only possible,
+                  but also fast and efficient. The talk will describe
+                  the driving requirements, assumptions made, and
+                  design trade offs that were considered in developing
+                  the baseline architecture for the LSST
+                  database. Details of its prototype implementation,
+                  Qserv, will be given, highlighting its features,
+                  status, and potential for usage outside LSST and
+                  even outside astronomy.},
+}
+
+@ARTICLE{2015IAUGA..2258269N,
+  author =       {{Narayan}, G. and {Snodgrass}, R. and {Keceioglu},
+                  J. and {Saha}, A. and {Matheson}, T. and {Seaman},
+                  R. and {Jenness}, T. and {Day Toeniskotter}, J. and
+                  {Yang}, S. and {Wang}, Z. and {Dempsey}, J.},
+  title =        "{ANTARES: Hunting the ''rarest of the rare'' in the
+                  time-domain}",
+  journal =      {IAU General Assembly},
+  year =         2015,
+  month =        aug,
+  volume =       22,
+  pages =        58269,
+  adsurl =       {http://adsabs.harvard.edu/abs/2015IAUGA..2258269N},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015IAUGA..2256348J,
+  author =       {{Juric}, M. and {Jones}, L. and {Axelrod}, T. and
+                  {Ivezic}, Z.  },
+  title =        "{Identifying and Characterizing Asteroids with
+                  LSST}",
+  journal =      {IAU General Assembly},
+  year =         2015,
+  month =        aug,
+  volume =       22,
+  pages =        56348,
+  adsurl =       {http://adsabs.harvard.edu/abs/2015IAUGA..2256348J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Misc{2016bosch-desc,
+  author =       {Jim Bosch},
+  title =        {Data Management Status},
+  month =        oct,
+  year =         2015,
+  note =         {Presented at the DEC 2015 Fall Meeting, Argonne
+                  National Laboratory},
+  url =          {http://dx.doi.org/10.5281/zenodo.47334},
+  doi =          {10.5281/zenodo.47334},
+}
+
+@Unpublished{2015hoblitt-puppet,
+  author =       {Josh Hoblitt},
+  title =        {Puppet vs Jenkins: A Tale of Types and Providers},
+  note =         {Talk presented at PuppetConf 2015, Portland},
+  month =        oct,
+  year =         2015,
+  url =
+                  {https://puppetlabs.com/presentations/puppet-vs-jenkins-tale-types-and-providers},
+  abstract =     {Not all software is "Configuration Management
+                  Friendly." In fact, some packages seem as if they
+                  were designed to be "Configuration Management
+                  Resistant." Jenkins is an archetype of how software
+                  can frustrate attempts at automation. A number of
+                  "DevOps Despair"-inducing behaviors by the butler
+                  will be discussed. Conversely, Puppet's resource
+                  model has inherent strong assumptions as to how
+                  software behavior should be modeled. It also has a
+                  split personality between the DSL and natives
+                  types. A tale, fraught with peril, of attempting to
+                  implement a family of types and providers with
+                  common configuration will be told.},
+}
+
+@Unpublished{2015juric-astroinformatics,
+  author =       {Mario Juric},
+  title =        {Large Sky Surveys: Entering the Era of
+                  Software-Bound Astronomy},
+  note =         {Presented at Astroinformatics 2015, Dubrovnik},
+  month =        oct,
+  year =         2015,
+  url =          {http://iszd.hr/AstroInfo2015/program.php}
+}
+
+@INPROCEEDINGS{2015DPS....4731222J,
+  author =       {{Jones}, L. and {Brown}, M. and {Ivezi{\'c}}, Z. and
+                  {Juri{\'c}}, M. and {Malhotra}, R. and {Trilling},
+                  D.},
+  title =        "{Solar System science with the Large Synoptic Survey
+                  Telescope}",
+  booktitle =    {AAS/Division for Planetary Sciences Meeting
+                  Abstracts},
+  year =         2015,
+  series =       {AAS/Division for Planetary Sciences Meeting
+                  Abstracts},
+  volume =       47,
+  month =        nov,
+  pages =        {\#312.22},
+  adsurl =       {http://adsabs.harvard.edu/abs/2015DPS....4731222J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Unpublished{2015kantor-ngvla,
+  author =       {Jeff Kantor},
+  title =        {Computing for ngVLA: Lessons from LSST},
+  note =         {Presented at Second ngVLA Technical Workshop, Socorro, NM},
+  url =
+                  {https://science.nrao.edu/science/meetings/2015/ngvla-tech-workshop/program},
+  month =        dec,
+  year =         2015,
+}
+
+@Unpublished{2015bosch-wlsys,
+  author =       {J. Bosch},
+  title =        "{Correcting sensor systematics in DM}",
+  note =         "{Presented at LSST Weak Lensing Science: A Workshop on the Impact
+                  of the Last Kiloparsec}",
+  url =
+                  {https://indico.bnl.gov/getFile.py/access?contribId=11&resId=1&materialId=slides&confId=1604},
+  month =        dec,
+  year =         2015,
+}
+
+@inproceedings{2016jenness-adass,
+  author =       "Tim Jenness",
+  title =        "{The LSST Data Processing Software Stack: Summer
+                  2015 Release}",
+  booktitle =    "ADASS XXV",
+  year =         2016,
+  editor =       "Lorente, N.~P.~F. and Shortridge, K.",
+  volume =       "TBD",
+  series =       "ASP Conf.\ Ser.",
+  pages =        "TBD",
+  publisher =    "ASP",
+  archivePrefix ="arXiv",
+  eprint =       {arXiv:1511.06790},
+  address =      "San Francisco",
+}
+
+@inproceedings{2016juric-adass,
+  author =       "Mario Juric and others",
+  title =        "{The LSST Data Management System}",
+  booktitle =    "ADASS XXV",
+  year =         2016,
+  editor =       "Lorente, N.~P.~F. and Shortridge, K.",
+  volume =       "TBD",
+  series =       "ASP Conf.\ Ser.",
+  pages =        "TBD",
+  publisher =    "ASP",
+  address =      "San Francisco",
+  archivePrefix ="arXiv",
+  eprint =       {arXiv:1512.07914},
+  talkdoi =      {10.5281/zenodo.45161},
+}
+
+@inproceedings{2016wu-adass,
+  author =       "Xiuqin Wu and David Ciardi and Gregory
+                  Dubois-Felsmann and Tatiana Goldina and Steve Groom
+                  and Loi Ly and Trey Roby",
+  title =        "{IPAC Firefly Development Roadmap}",
+  booktitle =    "ADASS XXV",
+  year =         2016,
+  editor =       "Lorente, N.~P.~F. and Shortridge, K.",
+  volume =       "TBD",
+  series =       "ASP Conf.\ Ser.",
+  pages =        "TBD",
+  publisher =    "ASP",
+  address =      "San Francisco",
+  talkdoi =      {10.5281/zenodo.45299},
+}
+
+@INPROCEEDINGS{2016AAS...22734806D,
+  author =       {{Dubois-Felsmann}, G.~P. and {Goldina}, T. and {Ly},
+                  L. and {Roby}, W. and {Wu}, X. and {Zhang}, L.},
+  title =        "{User extensibility of the Firefly astronomical
+                  visualization software}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2016,
+  series =       {American Astronomical Society Meeting Abstracts},
+  volume =       227,
+  month =        jan,
+  eid =          {\#348.06},
+  pages =        {\#348.06},
+  doi =          {10.5281/zenodo.44653},
+  adsurl =       {http://adsabs.harvard.edu/abs/2016AAS...22734806D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016AAS...22734815J,
+  author =       {{Jenness}, T. and {LSST Data Management Team}},
+  title =        "{The LSST Software Stack}",
+  booktitle =    {American Astronomical Society Meeting Abstracts},
+  year =         2016,
+  series =       {American Astronomical Society Meeting Abstracts},
+  volume =       227,
+  month =        jan,
+  eid =          {\#348.15},
+  pages =        {\#348.15},
+  doi =          {10.5281/zenodo.44634},
+  adsurl =       {http://adsabs.harvard.edu/abs/2016AAS...22734815J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@misc{2016sick-aas,
+  author =       {Sick, Jonathan},
+  title =        "{LSST DM Community Resources}",
+  month =        jan,
+  year =         2016,
+  note =         {NSF Pavilion Talk given at AAS 227.},
+  doi =          {10.5281/zenodo.44643},
+  url =          {http://dx.doi.org/10.5281/zenodo.44643}
+}
+
+@misc{2016nidever-aas,
+  author =       {Nidever, David L.},
+  title =        "{Evaluating the LSST Science Pipelines with
+                  Precursor Datasets}",
+  month =        jan,
+  year =         2016,
+  note =         {{NSF Pavilion talk at the 227th American
+                  Astronomical Society Meeting}},
+  doi =          {10.5281/zenodo.44673},
+  url =          {http://dx.doi.org/10.5281/zenodo.44673}
+}
+
+@misc{2016ciardi-aas,
+  author =       {Ciardi, David R.},
+  title =        "{LSST and Synergies with the VO}",
+  month =        jan,
+  year =         2016,
+  note =         {{Talk presented at the US Virtual Observatory
+                  Alliance Annual Meeting held at the Annual
+                  Astronomical Society meeting 227.}},
+  doi =          {10.5281/zenodo.44635},
+  url =          {http://dx.doi.org/10.5281/zenodo.44635}
+}
+
+@Misc{2016nidever-leiden,
+  author =       {David L. Nidever},
+  title =        "{Mapping the LMC outskirts with DECam}",
+  month =        feb,
+  year =         2016,
+  note =         {Presented at Globular Clusters and Galaxy Halos,
+                  Leiden},
+  doi =          {10.5281/zenodo.47537},
+  url =          {http://dx.doi.org/10.5281/zenodo.47537},
+}
+
+@Misc{2016juric-desc,
+  author =       {Mario Juric and Robert Lupton},
+  title =        "{LSST Data Management Brief Status Update}",
+  month =        mar,
+  year =         2016,
+  note =         {{Talk presented at the Winter 2016 LSST DESC Meeting
+                  held at SLAC.}},
+  doi =          {10.5281/zenodo.47280},
+  url =          {http://dx.doi.org/10.5281/zenodo.47280},
+}
+
+@INPROCEEDINGS{2016pyas.confE..17P,
+   author = {{Parejko}, J. and {Jenness}, T. and {Owen}, R.},
+    title = "{LSST Software: Where we are and where we're going}",
+booktitle = {Python in Astronomy 2016},
+     year = 2016,
+    month = mar,
+      eid = {17},
+    pages = {17},
+      doi = {10.5281/zenodo.48414},
+   adsurl = {http://adsabs.harvard.edu/abs/2016pyas.confE..17P},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016pyas.confE..28O,
+   author = {{Owen}, R.},
+    title = "{Python Linters}",
+booktitle = {Python in Astronomy 2016},
+     year = 2016,
+    month = mar,
+      eid = {28},
+    pages = {28},
+      doi = {10.5281/zenodo.48410},
+   adsurl = {http://adsabs.harvard.edu/abs/2016pyas.confE..28O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016pyas.confE..27J,
+   author = {{Jenness}, T.},
+    title = "{Python in Astronomy: ADS {\amp} Zenodo}",
+booktitle = {Python in Astronomy 2016},
+     year = 2016,
+    month = mar,
+      eid = {27},
+    pages = {27},
+      doi = {10.5281/zenodo.48406},
+   adsurl = {http://adsabs.harvard.edu/abs/2016pyas.confE..27J},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Misc{2016jenness-astropy,
+  author =       {Tim Jenness},
+  title =        "{LSST Data Management Code Overview}",
+  month =        mar,
+  year =         2016,
+  note =         {Presented at LSST/Astropy Summit, March 2016,
+                  Seattle},
+  doi =          {10.5281/zenodo.48434},
+  url =          {http://dx.doi.org/10.5281/zenodo.48434},
+}
+
+@Misc{2016bosch-astropy,
+  author =       {Jim Bosch},
+  title =        "{LSST Classes, as AstroPy Spin-Off Candidates}",
+  month =        mar,
+  year =         2016,
+  note =         {Presented at LSST/Astropy Summit, March 2016,
+                  Seattle},
+  doi =          {10.5281/zenodo.48435},
+  url =          {http://dx.doi.org/10.5281/zenodo.48435},
+}
+
+@Misc{2016ivezic-photoz,
+  author =       {Zeljko Ivezic},
+  title =        "{The impact of photo-z on LSST science requirements}",
+  month =        apr,
+  year =         2016,
+  url =
+                  {https://docs.google.com/viewer?a=v&pid=sites&srcid=ZGVmYXVsdGRvbWFpbnxwaXR0cGhvdG96d29ya3Nob3AyMDE2fGd4OjMwZDZmNWEwYjhhMmY3Zjk},
+  note =         {Presented at the LSST Photo-z Workshop, Pittsburgh,
+                  April 5, 2016},
+}
+
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{2016bolton-oir,
+    author = {Adam Bolton and David Ciardi and Knut Olsen},
+    title = {Datasphere 2023},
+    month = may,
+    year = 2016,
+    note = {Presented at the LSST OIR workshop, Tucson, May 2016},
+    url = {http://dx.doi.org/10.5281/zenodo.51772},
+    doi = {10.5281/zenodo.51772},
+}
+
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{2016ciardi-ivoa,
+    author = {David Ciardi},
+    title = "{Large Synoptic Survey Telescope and Synergies with the VO}",
+    month = may,
+    year = 2016,
+    note = {Presentation at the Northern Spring IVOA Meeting, South Africa},
+    url = {http://wiki.ivoa.net/internal/IVOA/InterOpMay2016Focus/LSST_IVOA_20160506c.pdf},
+}
+
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{2016swinbank-ivoa,
+    author = {John Swinbank},
+    title = "{VOEvent Transport Protocol}",
+    month = may,
+    year = 2016,
+    note = {Presentation at the Northern Spring IVOA Meeting, South Africa},
+    url = {http://wiki.ivoa.net/internal/IVOA/InterOpMay2016-TDIG/2016-05_-_VTP_at_InterOp.pdf},
+}
+
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{2016vanklaveren-ivoa,
+    author = {Brian van Klaveren},
+    title = "{LSST Data Access and VO: Pathfinding through TAP, ADQL and beyond}",
+    month = may,
+    year = 2016,
+    note = {Presentation at the Northern Spring IVOA Meeting, South Africa},
+    url = {http://wiki.ivoa.net/internal/IVOA/InterOpMay2016-DAL/LSST_DAX_IVOA_Interop_May-2016.pdf},
+}
+
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{2016juric-lssteurope,
+    author = {Mario Juric},
+    title = "{LSST Data Products}",
+    month = jun,
+    year = 2016,
+    note = {Presented on 2016-06-20 at the LSST@Europe2 conference held in Serbia},
+    url = {https://project.lsst.org/meetings/lsst-europe-2016/sites/lsst.org.meetings.lsst-europe-2016/files/02\%20-\%20juric-LSST-LSSTEurope2-DataProducts-4.pptx}
+}
+
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{2016economou-ska,
+    author = {Frossie Economou},
+    title = "{Software development with distributed teams in large astronomy projects: The LSST experience (so far)}",
+    month = jun,
+    year = 2016,
+    note = {Seminar given at SKA Headquarters, Jodrell Bank, 23rd June 2016},
+    url = {http://dx.doi.org/10.5281/zenodo.56342},
+    doi = {10.5281/zenodo.56342},
+}
+
+% Optional fields: author, title, howpublished, month, year, note
+@MISC{2016connolly-spie,
+    author = {Andrew Connolly},
+    title = "{Surveying the Sky with the LSST: Software as the instrument of the Next Decade}",
+    month = jun,
+    year = 2016,
+    note = {Plenary talk at the SPIE Astronomical Telescopes and Instrumentation Conference, Edinburgh, UK},
+    url = {http://dx.doi.org/10.5281/zenodo.56737},
+    doi = {10.5281/zenodo.56737},
+}
+
+@MISC{2016kantor-spie,
+    author = {Kantor, Jeff and Long, Kevin and Becla, Jacek and Economou, Frossie and
+              Gelman, Margaret and Juric, Mario and Lambert, Ron and Krughoff, Simon K. and
+              Swinbank, John D. and Wu, Xiuqin},
+    title = "{Agile software development in an earned value world: a survival guide}",
+    month = jun,
+    year = 2016,
+    note = {Talk at the SPIE Astronomical Telescopes and Instrumentation Conference, Edinburgh, UK},
+    url = {http://dx.doi.org/10.5281/zenodo.56593},
+    doi = {10.5281/zenodo.56593},
+}
+
+@MISC{2016jenness-spie,
+    author = {Jenness, Tim},
+    title = "{Investigating interoperability of the LSST Data Management software stack with Astropy}",
+    month = jun,
+    year = 2016,
+    note = {Talk at the SPIE Astronomical Telescopes and Instrumentation Conference, Edinburgh, UK},
+    url = {http://dx.doi.org/10.5281/zenodo.48434},
+    doi = {10.5281/zenodo.48434},
+}
+
+@MISC{2016economou-spie,
+    author = {Economou, Frossie},
+    title = "{The astronomer, the software engineer, and the cloud}",
+    month = jun,
+    year = 2016,
+    note = {Talk at the SPIE Astronomical Telescopes and Instrumentation Conference, Edinburgh, UK},
+    url = {http://dx.doi.org/10.5281/zenodo.},
+    doi = {10.5281/zenodo.},
+}
+
+@MISC{2016roby-spie,
+    author = {William W. Roby},
+    title = "{Firefly: embracing future web technologies}",
+    month = jun,
+    year = 2016,
+    note = {Talk at the SPIE Astronomical Telescopes and Instrumentation Conference, Edinburgh, UK},
+    url = {http://dx.doi.org/10.5281/zenodo.},
+    doi = {10.5281/zenodo.},
+}
+
+@INPROCEEDINGS{2016SPIE.9913E..09L,
+   author = {{Lotz}, P.~J. and {Dubois-Felsmann}, G.~P. and {Lim}, K.-T. and
+	{Johnson}, T. and {Chandrasekharan}, S. and {Mills}, D. and
+	{Daly}, P. and {Schumacher}, G. and {Delgado}, F. and {Pietrowicz}, S. and
+	{Selvy}, B. and {Sebag}, J. and {Marshall}, S. and {Sundararaman}, H. and
+	{Contaxis}, C. and {Bovill}, R. and {Jenness}, T.},
+    title = "{LSST control software component design}",
+booktitle = {Software and Cyberinfrastructure for Astronomy IV},
+     year = 2016,
+   series = {\procspie},
+   volume = 9913,
+    month = aug,
+      eid = {991309},
+    pages = {991309},
+      doi = {10.1117/12.2231796},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9913E..09L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9911E..0DS,
+   author = {{Selvy}, B.~M. and {Claver}, C. and {Willman}, B. and {Petravick}, D. and
+	{Johnson}, M. and {Reil}, K. and {Marshall}, S. and {Thomas}, S. and
+	{Lotz}, P. and {Schumacher}, G. and {Lim}, K.-T. and {Jenness}, T. and
+	{Jacoby}, S. and {Emmons}, B. and {Axelrod}, T.},
+    title = "{Using model based systems engineering for the development of the Large Synoptic Survey Telescope's operational plan}",
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9911,
+    month = aug,
+      eid = {99110D},
+    pages = {99110D},
+      doi = {10.1117/12.2233904},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9911E..0DS},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9913E..0GJ,
+   author = {{Jenness}, T. and {Bosch}, J. and {Owen}, R. and {Parejko}, J. and
+	{Sick}, J. and {Swinbank}, J. and {de Val-Borro}, M. and {Dubois-Felsmann}, G. and
+	{Lim}, K.-T. and {Lupton}, R.~H. and {Schellart}, P. and {Krughoff}, K.~S. and
+	{Tollerud}, E.~J.},
+    title = "{Investigating interoperability of the LSST data management software stack with Astropy}",
+booktitle = {Software and Cyberinfrastructure for Astronomy IV},
+     year = 2016,
+   series = {\procspie},
+   volume = 9913,
+    month = jul,
+      eid = {99130G},
+    pages = {99130G},
+      doi = {10.1117/12.2231313},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9913E..0GJ},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9910E..0FS,
+   author = {{Saha}, A. and {Wang}, Z. and {Matheson}, T. and {Narayan}, G. and
+	{Snodgrass}, R. and {Kececioglu}, J. and {Scheidegger}, C. and
+	{Axelrod}, T. and {Jenness}, T. and {Ridgway}, S. and {Seaman}, R. and
+	{Taylor}, C. and {Toeniskoetter}, J. and {Welch}, E. and {Yang}, S. and
+	{Zaidi}, T.},
+    title = "{ANTARES: progress towards building a 'broker' of time-domain alerts}",
+booktitle = {Observatory Operations: Strategies, Processes, and Systems VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9910,
+archivePrefix = "arXiv",
+   eprint = {1611.05914},
+ primaryClass = "astro-ph.IM",
+    month = jul,
+      eid = {99100F},
+    pages = {99100F},
+      doi = {10.1117/12.2232095},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9910E..0FS},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9911E..0NK,
+   author = {{Kantor}, J. and {Long}, K. and {Becla}, J. and {Economou}, F. and
+	{Gelman}, M. and {Juric}, M. and {Lambert}, R. and {Krughoff}, S. and
+	{Swinbank}, J.~D. and {Wu}, X.},
+    title = "{Agile software development in an earned value world: a survival guide}",
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9911,
+    month = aug,
+      eid = {99110N},
+    pages = {99110N},
+      doi = {10.1117/12.2233380},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9911E..0NK},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9913E..0YR,
+   author = {{Roby}, W. and {Wu}, X. and {Goldina}, T. and {Joliet}, E. and
+	{Ly}, L. and {Mi}, W. and {Wang}, C. and {Zhang}, L. and {Ciardi}, D. and
+	{Dubois-Felsmann}, G.},
+    title = "{Firefly: embracing future web technologies}",
+booktitle = {Software and Cyberinfrastructure for Astronomy IV},
+     year = 2016,
+   series = {\procspie},
+   volume = 9913,
+    month = jul,
+      eid = {99130Y},
+    pages = {99130Y},
+      doi = {10.1117/12.2233042},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9913E..0YR},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9906E..3BT,
+   author = {{Thomas}, S.~J. and {Chandrasekharan}, S. and {Lotz}, P. and
+	{Xin}, B. and {Claver}, C. and {Angeli}, G. and {Sebag}, J. and
+	{Dubois-Felsmann}, G.~P.},
+    title = "{LSST active optics system software architecture}",
+booktitle = {Ground-based and Airborne Telescopes VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9906,
+    month = aug,
+      eid = {99063B},
+    pages = {99063B},
+      doi = {10.1117/12.2231798},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9906E..3BT},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Misc{DevGuide,
+  author =       {{LSST Data Management}},
+	title =        "{LSST DM Developer Guide}",
+	url =          {https://developer.lsst.io/}
+}

--- a/{{cookiecutter.repo_name}}/lsstbib/lsst.bib
+++ b/{{cookiecutter.repo_name}}/lsstbib/lsst.bib
@@ -1,0 +1,1220 @@
+
+@DocuShare{Document-1386,
+  author =       {Jacek Becla},
+  title =        "{Database Ingest Tests}",
+  year =         2006,
+  month =        mar,
+  handle =       {Document-1386},
+}
+
+@DocuShare{Document-5356,
+  author =       {Tim Axelrod and Robyn Allsman and Jeff Kantor and Jon Myers and
+                  Francesco Pierfederici and Serge Monkewicz and Greg Daues and
+                  David Gehrig and Steve Pietrowicz and Raymond Plante and
+                  Jacek Becla and Kian-Tat Lim and Andrew Becker and Lynne Jones and
+                  Russell Owen and Nicole Silvestri and Robert H. Lupton and
+                  Jeff Bartels and Phil Pinto and Jeff Kantor and
+                  Michael Strauss and Don Sweeney},
+  title =        "{LSST Data Challenge 2}",
+  year =         2008,
+  month =        apr,
+  handle =       {Document-5356},
+}
+
+@DocuShare{Document-5373,
+  author =       {Phil Pinto and Jeff Kantor and Michael Strauss and Don Sweeney},
+  title =        "{Data Access White Paper}",
+  year =         2008,
+  month =        apr,
+  handle =       {Document-5373},
+}
+
+@DocuShare{Document-7025,
+  author =       {Jeff Kantor and Victor Krabbendam},
+  title =        "{DM Risk Register}",
+  year =         2011,
+  month =        aug,
+  handle =       {Document-7025},
+}
+
+@DocuShare{Document-8256,
+  author =       {Jacek Becla},
+  title =        "{Evaluation of Database Solutions}",
+  year =         2009,
+  month =        nov,
+  handle =       {Document-8256},
+}
+
+@DocuShare{Document-8590,
+  author =       {Andrew Rasmussen},
+  title =        "{Sensor Modeling for the LSST Camera Focal Plane: Current Status of SLAC Originated Code}",
+  year =         2015,
+  month =        jul,
+  handle =       {Document-8590},
+}
+
+@DocuShare{Document-9044,
+  author =       {Jeff Kantor and Tim Axelrod and Robyn Allsman
+                  and Mike Freemon and K-T Lim},
+  title =        "{Data Challenge 3b Overview}",
+  year =         2010,
+  month =        mar,
+  handle =       {Document-9044},
+}
+
+@DocuShare{Document-9224,
+  author =       {George Angeli and Robert McKercher},
+  title =        {Change Controlled Document Cover Page and Style Guide},
+  year =         2013,
+  month =        oct,
+  handle =       {Document-9224},
+}
+
+@DocuShare{Document-9541,
+  author =       {Ray Plante and Robyn Allsman and Tim Axelrood and Jacek Becla
+                  and Cristina Beldica and Greg Daues and Jeff Kantor and Jonathan Myers
+                  and Russell Owen and Steve Pietrowicz},
+  title =        {Results from Data Challenge 1},
+  year =         2010,
+  month =        jul,
+  handle =       {Document-9541},
+}
+
+@DocuShare{Document-10762,
+  author =       {Richard Shaw and Michael Strauss},
+  title =        {LSST Data Challenge Handbook Version 1.1},
+  year =         2011,
+  month =        aug,
+  handle =       {Document-10762},
+}
+
+@DocuShare{Document-11624,
+  author =       {{LSST Science Council}},
+  title =        {Optimization of LSST Deployment Parameters},
+  year =         2011,
+  month =        jul,
+  handle =       {Document-11624},
+}
+
+@DocuShare{Document-11625,
+  author =       {Jacek Becla and K-T Lim and Daniel Wang},
+  title =        "{Database Architecture}",
+  year =         2011,
+  month =        jul,
+  handle =       {Document-11625},
+}
+
+@DocuShare{Document-11701,
+  author =       {Jacek Becla and Kian-Tat Lim and Daniel Wang},
+  title =        {Evaluation of Solid State Disks},
+  year =         2011,
+  month =        jul,
+  handle =       {Document-11701},
+}
+
+@DocuShare{Document-11920,
+  author =       {George Angeli and Robert McKercher},
+  title =        {Document Cover Page and Style Guide},
+  year =         2013,
+  month =        oct,
+  handle =       {Document-11920},
+}
+
+@DocuShare{Document-13760,
+  author =       {Erin Carlson},
+  title =        "{Travel Request Instructions for AURA Employees}",
+  year =         2017,
+  month =        jan,
+  handle =       {Document-13760},
+}
+
+@DocuShare{Document-13762,
+  author =       {Erin Carlson},
+  title =        "{LSST Travel Summary Report Template}",
+  year =         2017,
+  month =        may,
+  handle =       {Document-13762},
+}
+
+@DocuShare{Document-15077,
+  author =        {Sidney Wolff},
+  title =         {LSST Project Overview},
+  year =          2013,
+  month=          sep,
+  handle =        {Document-15077},
+}
+
+@DocuShare{Document-15097,
+  author =       {K-T Lim},
+  title =        "{LSST Data Challenge Report: Summer 2013}",
+  year =         2013,
+  month =        sep,
+  handle =       {Document-15097},
+}
+
+@DocuShare{Document-15125,
+  author =       {Peter Yoachim and Lynne Jones and {\v
+                  Z}. {Ivezi{\'c}} and Tim Axelrod},
+  title =        {Photometric Self Calibration Design and Prototype},
+  year =         2013,
+  month =        oct,
+  handle =       {Document-15125},
+}
+
+@DocuShare{Document-15286,
+  author =       {Richard A. Shaw},
+  title =        {LSST Data Challenge Handbook: Summer 2012 Data Release},
+  year =         2012,
+  month =        aug,
+  handle =       {Document-15286},
+}
+
+@DocuShare{Document-15298,
+  author =       {J. Bosch and P. Gee and R. Owen and M. Juri\'c},
+  title =        {LSST DM S13 Report: Shapre Measurement Plans and Prototypes},
+  year =         2013,
+  month =        oct,
+  handle =       {Document-15298},
+}
+
+@DocuShare{Document-15299,
+  author =       {Richard A. Shaw},
+  title =        {LSST Data Challenge Handbook: Winter 2013 Early Data Release},
+  year =         2013,
+  month =        jan,
+  handle =       {Document-15299},
+}
+
+@DocuShare{Document-16168,
+  author =       {{LSST Systems Engineering}},
+  title =        {{LSST Key System Parameters Summary}},
+  year =         2014,
+  month =        jan,
+  handle =       {Document-16168},
+}
+
+@DocuShare{Document-26217,
+  author =       {Jeff Kantor},
+  title =        {Data Challenge 3b Performance Test 1.1},
+  year =         2010,
+  month =        aug,
+  handle =       {Document-26217},
+}
+
+@DocuShare{Document-26273,
+  author =       {Brian Selvy},
+  title =        {Risk \& Opportunity Management Report May 2017},
+  year =         2017,
+  month =        jul,
+  handle =       {Document-26273},
+}
+
+@DocuShare{Document-26276,
+  author =       {Jacek Becla and K-T Lim and Daniel Wang},
+  title =        {Scalable Partitioning},
+  year =         2013,
+  month =        feb,
+  handle =       {Document-26276},
+}
+
+@DocuShare{LCA-227,
+  author =       {Martin Nordby and Nadine Kurita and Frank O'Neill and Darren Marsh},
+  title =        {LSST Camera Quality Implementation Plan},
+  year =         2014,
+  month =        sep,
+  handle =       {LCA-227},
+}
+
+@DocuShare{LDM-17,
+  author =       {Tim Axelrod and others},
+  title =        {LSST Data Challenge 3a Final Report},
+  year =         2009,
+  month =        aug,
+  handle =       {LDM-17},
+}
+
+@DocuShare{LDM-129,
+  author =       {Mike Freemon and Jeff Kantor},
+  title =        {Data Management Infrastructure Design},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-129},
+}
+
+@DocuShare{LDM-130,
+  author =       {Unknown},
+  title =        {LSST Science User Interface and Tools Requirements},
+  institution =  {IPAC},
+  year =         2017,
+  month =        sep,
+  handle =       {LDM-130},
+}
+
+@DocuShare{LDM-131,
+  author =       {Schuyler {van Dyk} and Deborah Levine},
+  title =        {Science User Interface and Science User Tools
+                  Conceptual Design},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-131},
+}
+
+@DocuShare{LDM-133,
+  author =       {Mario Juri\'c and Kian-Tat Lim and Jeff Kantor},
+  title =        {Data Management UML Domain Model},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-133},
+}
+
+@DocuShare{LDM-134,
+  author =       {Mario Juri\'c and Robyn Allsman and Jeff Kantor},
+  title =        {Data Management Applications UML Use Case Model},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-134},
+}
+
+@DocuShare{LDM-135,
+  author =       {Jacek Becla and Daniel Wang and Serge Monkewitz and
+                  K-T Lim and Douglas Smith and Bill Chickering},
+  title =        {Database Design},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-135},
+}
+
+@DocuShare{LDM-138,
+  author =       {Jeff Kantor and Tim Axelrod and Kian-Tat Lim},
+  title =        {Data Management Compute Sizing Model},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-138},
+}
+
+@DocuShare{LDM-139,
+  author =       {Jacek Becla and K.-T. Lim},
+  title =        {Data Management Storage Sizing and I/O Model
+                  Explanation},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-139},
+}
+
+@DocuShare{LDM-140,
+  author =       {Kian-Tat Lim and Chris Smith and Tim Axelrod and
+                  Gregory Dubois-Felsmann and Mike Freemon},
+  title =        {Data Management Compute Sizing Explanation},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-140},
+}
+
+@DocuShare{LDM-141,
+  author =       {Jacek Becla and K.-T. Lim},
+  title =        {Data Management Storage Sizing and I/O Model},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-141},
+}
+
+@DocuShare{LDM-142,
+  author =       {Jeff Kantor},
+  title =        {Network Sizing Model},
+  year =         2017,
+  month =        jan,
+  handle =       {LDM-142},
+}
+
+@DocuShare{LDM-143,
+  author =       {Mike Freemon and Steve Pietrowicz},
+  title =        {Site Specific Infrastructure Estimation Explanation},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-143},
+}
+
+@DocuShare{LDM-144,
+  author =       {Mike Freemon and Steve Pietrowicz and Jason Alt},
+  title =        {Site Specific Infrastructure Estimation Model},
+  year =         2016,
+  month =        jan,
+  handle =       {LDM-144},
+}
+
+@DocuShare{LDM-146,
+  author =       {Kian-Tat Lim and Robyn Allsman and Jeff Kantor},
+  title =        {Data Management Middleware UML Use Case and Activity
+                  Model},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-146},
+}
+
+@DocuShare{LDM-148,
+  author =       {K.-T. Lim and J. Bosch and G. Dubois-Felsmann and T. Jenness
+                  and J. Kantor and W. O'Mullane and D. Petravick and
+                  {The DM Leadership Team}},
+  title =        {Data Management System Design},
+  year =         2017,
+  month =        jul,
+  handle =       {LDM-148},
+}
+
+@DocuShare{LDM-151,
+  author =       {John D. Swinbank and others},
+  title =        {Data Management Science Pipelines Design},
+  year =         2017,
+  month =        may,
+  handle =       {LDM-151},
+}
+
+@DocuShare{LDM-152,
+  author =       {Kian-Tat Lim and Gregory Dubois-Felsmann and M. Johnson
+                  and M. Juri\'c and D. Petravick},
+  title =        {Data Management Middleware Design},
+  year =         2017,
+  month =        jul,
+  handle =       {LDM-152},
+}
+
+@DocuShare{LDM-153,
+  author =      {J. Becla},
+  title =       {LSST Database Baseline Schema},
+  year =        2013,
+  handle =      {LDM-153},
+}
+
+@DocuShare{LDM-156,
+  author =       {Jonathan Myers and Lynne Jones and Tim Axelrod},
+  title =        {Moving Object Pipeline System Design},
+  year =         2013,
+  month =        oct,
+  handle =       {LDM-156},
+}
+
+@DocuShare{LDM-226,
+  author =       {Richard A. Shaw and Mario Juri\'c and Andrew Becker and
+                  K. Simon Krughoff and K-T Lim and Yusra Al Sayyad and
+                  Jacek Becla and Robin Allsman and Tim Axelrod and
+                  Steve Bickerton and James Bosch and Andrew Connolly and
+                  Gregory E. Daues and Scott Daniel and
+                  Gregory P. Dubois-Felsmann and Mike Freemon and Perry Gee and
+                  William Glick and Steve Groom and Mike Jarvis and Jeff Kantor and
+                  Dustin Lang and Ron Lambert and Robert Lupton and
+                  Serge Monkewitz and Knut Olsen and Russell Owen and
+                  Steve Pietrowicz and Raymond Plante and Paul Price and
+                  Douglas Smith and Schuyler Van Dyk and Daniel Wang},
+  title =        "{LSST Data Challenge Report: Summer 2012/early-Winter 2013}",
+  year =         2013,
+  month =        apr,
+  handle =       {LDM-226},
+}
+
+@DocuShare{LDM-227,
+  author =       {Andrew Becker and Simon Krughoff and Andrew Connolly and
+                  Russell Owen and Paul Price and Robert Lupton and Dustin Lang and
+                  Jim Bosch and Robyn Allsman and Yusra Al Sayyad and Jacek Becla and
+                  Steve Bickerton and Scott Daniel and Greg Daues and
+                  Gregory Dubois-Felsmann and Mike Freemon and Perry Gee and
+                  Bill Glick and Steve Groom and Mario Juri\'c and Jeff Kantor and
+                  Ron Lambert and Kian-Tat Lim and Bruce Mather and Serge Monkewitz and
+                  Knut Olsen and Steve Pietrowicz and Ray Plante and Dick Shaw and
+                  Douglas Smith and Schuyler Van Dyk and Daniel Wang},
+  title =        {Report on Late Winter2013 Production: Image Differencing},
+  year =         2013,
+  month =        apr,
+  handle =       {LDM-227},
+}
+
+@DocuShare{LDM-230,
+  author =       {D. Petravick and M. Gelman},
+  title =        {Concept of Operations for the LSST Data Facility Services},
+  year =         2017,
+  month =        jul,
+  handle =       {LDM-230},
+}
+
+@DocuShare{LDM-240,
+  author =       {Jeff Kantor and Mario Juri\'c and Kian-Tat Lim},
+  title =        {Data Management Releases},
+  year =         2016,
+  month =        feb,
+  handle =       {LDM-240},
+}
+
+@DocuShare{LDM-294,
+  author =       {William O'Mullane and John Swinbank and Mario Juri\'c
+                  and {DMLT}},
+  title =        {Data Management Organization and Management},
+  year =         2017,
+  month =        jul,
+  handle =       {LDM-294},
+}
+
+@DocuShare{LDM-463,
+  author =       {Jacek Becla and Nate Pease},
+  title =        {Data Access Design},
+  year =         2017,
+  month =        apr,
+  handle =       {LDM-463},
+}
+
+@DocuShare{LDM-472,
+  author =       {Jacek Becla and Frossie Economou and Fritz Mueller and
+                  Margaret Johnson and K. Simon Krughoff and K-T Lim and
+                  John Swinbank and Xiuqin Wu},
+  title =        {LSST DM Project Management and Tools},
+  year =         2017,
+  month =        feb,
+  handle =       {LDM-472},
+}
+
+@DocuShare{LDM-482,
+  author =       {David Ciardi and Gregory Dubois-Felsmann},
+  title =        {Data Access Policy for the Data Management Prototype DAC},
+  year =         2016,
+  month =        aug,
+  handle =       {LDM-482},
+}
+
+@DocuShare{LDM-492,
+  author =       {David R. Ciardi and Xiuqin Wu and Gregory
+                  Dubois-Felsmann},
+  title =        {A Vision for the Science User Interface and Tools},
+  institution =  {IPAC},
+  year =         2016,
+  month =        sep,
+  handle =       {LDM-492},
+}
+
+@DocuShare{LDM-493,
+  author =       {Jonathan Sick},
+  title =        {Data Management Documentation Architecture},
+  year =         2016,
+  month =        nov,
+  handle =       {LDM-493},
+}
+
+@DocuShare{LDM-502,
+  author =       {David Nidever and Frossie Economou},
+  title =        {The Measurement and Verification of DM Key Performance Metrics},
+  year =         2016,
+  month =        may,
+  handle =       {LDM-502},
+}
+
+@DocuShare{LDM-503,
+  author =       {William O'Mullane and Mario Juri\'c and Frossie
+                  Economou},
+  title =        {Data Management Test Plan},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-503},
+}
+
+@DocuShare{LDM-512,
+  author =       {Tim Jenness and William O'Mullane},
+  title =        {Data Management Risk Assessment Process},
+  year =         2017,
+  month =        apr,
+  handle =       {LDM-512},
+}
+
+@DocuShare{LDM-513,
+  author =       {Jim Bosch},
+  title =        {Proposal for Deblender Outputs as Level 2 Data Products},
+  year =         2017,
+  month =        apr,
+  handle =       {LDM-513},
+}
+
+@DocuShare{LDM-522,
+  author =       {Frossie Economou and Michael Wood-Vasey},
+  title =        {DM Science Quality Data Assurance System Conceptual Design},
+  year =         2017,
+  month =        may,
+  handle =       {LDM-522},
+}
+
+@DocuShare{LDM-523,
+  author =       {C. T. Slater and R. L. Jones and E. Bellm and M. Juri\'c},
+  title =        {Impact of a Heterogeneous Focal Plane on LSST Image Differencing},
+  year =         2017,
+  month =        may,
+  handle =       {LDM-523},
+}
+
+@DocuShare{LDM-532,
+  author =       {Unknown},
+  title =        {NCSA Enclave Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-532},
+}
+
+@DocuShare{LDM-533,
+  author =       {Unknown},
+  title =        {Level 1 System Software Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-533},
+}
+
+@DocuShare{LDM-534,
+  author =       {John D. Swinbank},
+  title =        {Level 2 System Software Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-534},
+}
+
+@DocuShare{LDM-535,
+  author =       {Unknown},
+  title =        {Data Backbone Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-535},
+}
+
+@DocuShare{LDM-536,
+  author =       {Unknown},
+  title =        {Data Backbone Data Services Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-536},
+}
+
+@DocuShare{LDM-537,
+  author =       {Unknown},
+  title =        {Data Backbone Infrastructure Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-537},
+}
+
+@DocuShare{LDM-538,
+  author =       {Unknown},
+  title =        {Base Enclave Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-538},
+}
+
+@DocuShare{LDM-539,
+  author =       {Unknown},
+  title =        {Data Access Center Enclave Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-539},
+}
+
+@DocuShare{LDM-540,
+  author =       {Unknown},
+  title =        {LSST Science Platform Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-540},
+}
+
+@DocuShare{LDM-541,
+  author =       {Unknown},
+  title =        {Commissioning Cluster Enclave Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-541},
+}
+
+@DocuShare{LDM-542,
+  author =       {Gregory Dubois-Felsmann and Kian-Tat Lim and Xiuqin Wu and Frossie Economou and Fritz Mueller and Brian Van Klaveren and Kenny Lo},
+  title =        {LSST Science Platform Design},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-542},
+}
+
+@DocuShare{LDM-552,
+  author =       {Fritz Mueller},
+  title =        {Qserv Software Test Specification},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-552},
+}
+
+@DocuShare{LDM-553,
+  author =       {William O'Mullane and John D. Swinbank and Mario Juri\'c and {DMLT}},
+  title =        {Evolution of the Data Management Plan and Organization},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-553},
+}
+
+@DocuShare{LDM-554,
+  author =       {David Ciardi and Gregory Dubois-Felsmann},
+  title =        {Science Platform Requirements},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-554},
+}
+
+@DocuShare{LDM-555,
+  author =       {Jacek Becla},
+  title =        {Data Management Database Requirements},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-555},
+}
+
+@DocuShare{LDM-556,
+  author =       {Gregory Dubois-Felsmann},
+  title =        {Data Management Middleware Requirements},
+  year =         2017,
+  month =        jun,
+  handle =       {LDM-556},
+}
+
+@DocuShare{LPM-17,
+  author =       {{\v Z}. {Ivezi{\'c}} and {The LSST Science
+                  Collaboration}},
+  title =        "{LSST Science Requirements Document}",
+  year =         2011,
+  month =        jul,
+  handle =       {LPM-17},
+}
+
+@DocuShare{LPM-19,
+  author =       {George Angeli and Robert McKercher},
+  title =        {Change Control Process},
+  year =         2015,
+  month =        dec,
+  handle =       {LPM-19},
+}
+
+@DocuShare{LPM-20,
+  author =       {Victor Krabbendam and Brian Selvy},
+  title =        {Risk \& Opportunity Management Plan},
+  year =         2015,
+  month =        aug,
+  handle =       {LPM-20},
+}
+
+@DocuShare{LPM-43,
+  author =       {Robert McKercher},
+  title =        {WBS Structure},
+  year =         2016,
+  month =        jul,
+  handle =       {LPM-43},
+}
+
+@DocuShare{LPM-44,
+  author =       {Robert McKercher},
+  title =        {WBS Dictionary},
+  year =         2016,
+  month =        jul,
+  handle =       {LPM-44},
+}
+
+@DocuShare{LPM-51,
+  author =       {Robert McKercher},
+  title =        {Document Management Plan},
+  year =         2013,
+  month =        aug,
+  handle =       {LPM-51},
+}
+
+@DocuShare{LPM-55,
+  author =       {Donald Sweeney and Robert McKercher},
+  title =        {Project Quality Assurance Plan},
+  year =         2013,
+  month =        aug,
+  handle =       {LPM-55},
+}
+
+@DocuShare{LPM-72,
+  author =       {Victor Krabbendam},
+  title =        {Scope Options},
+  year =         2015,
+  month =        oct,
+  handle =       {LPM-72},
+}
+
+@DocuShare{LPM-73,
+  author =       {Sidney Wolff},
+  title =        {Operations Plan},
+  year =         2013,
+  month =        oct,
+  handle =       {LPM-73},
+}
+
+@DocuShare{LPM-81,
+  author =       {Jeff Kantor and Victor Krabbendam},
+  title =        {Cost Estimating Plan},
+  year =         2015,
+  month =        aug,
+  handle =       {LPM-81},
+}
+
+@DocuShare{LPM-98,
+  author =       {Kevin E. Long},
+  title =        {LSST Project Controls System Description},
+  year =         2016,
+  month =        dec,
+  handle =       {LPM-98},
+}
+
+@DocuShare{LPM-121,
+  author =       {Donald L. Petravick and Alexander Withers},
+  title =        {LSST Master Information Security Policy},
+  year =         2016,
+  month =        sep,
+  handle =       {LPM-121},
+}
+
+@DocuShare{LPM-122,
+  author =       {Donald Petravick},
+  title =        {LSST Information Classification Policy},
+  year =         2015,
+  month =        aug,
+  handle =       {LPM-122},
+}
+
+@DocuShare{LPM-162,
+  author =       {{Project Science Team}},
+  title =        {Project Publication Policy},
+  year =         2015,
+  month =        aug,
+  handle =       {LPM-162},
+}
+
+@DocuShare{LPM-191,
+  author =       {Daniel Calabrese},
+  title =        "{Travel Policy}",
+  year =         2017,
+  month =        may,
+  handle =       {LPM-191},
+}
+
+@DocuShare{LSE-16,
+  author =       {Robyn Allsman and Gregory Dubois-Felsmann and Jeff Kantor},
+  title =        {LSST Software Development Plan},
+  year =         2009,
+  month =        may,
+  handle =       {LSE-16},
+}
+
+@DocuShare{LSE-17,
+  author =       {Charles Claver and George Angeli and Brian Selvy},
+  title =        {Systems Engineering Management Plan},
+  year =         2016,
+  month =        jan,
+  handle =       {LSE-17},
+}
+
+@DocuShare{LSE-29,
+  author =       {Charles F. Claver and {The LSST Systems Engineering
+                  Integrated Project Team}},
+  title =        {LSST System Requirements},
+  year =         2016,
+  month =        aug,
+  handle =       {LSE-29},
+}
+
+@DocuShare{LSE-30,
+  author =       {Charles F. Claver and {The LSST Systems Engineering
+                  Integrated Project Team}},
+  title =        {LSST System Requirements},
+  year =         2016,
+  month =        aug,
+  handle =       {LSE-30},
+}
+
+@DocuShare{LSE-39,
+  author =       {Chuck Claver and Gregory Dubois-Felsmann},
+  title =        "{LSST Document Tree}",
+  year =         2010,
+  month =        mar,
+  handle =       {LSE-39},
+}
+
+@DocuShare{LSE-61,
+  author =       {Gregory Dubois-Felsmann},
+  title =        {LSST Data Management Subsystem Requirements},
+  year =         2016,
+  month =        feb,
+  handle =       {LSE-61},
+}
+
+@DocuShare{LSE-63,
+  author =       {Tony Tyson and {DQA Team} and {Science
+                  Collaboration}},
+  title =        {Data quality Assurance Plan: Requirements for the
+                  LSST Data Quality Assessment Framework},
+  year =         2017,
+  month =        may,
+  handle =       {LSE-63},
+}
+
+@DocuShare{LSE-68,
+  author =       {Gregory Dubois-Felsmann},
+  title =        {Camera Data Acquisition Interface},
+  year =         2015,
+  month =        jun,
+  handle =       {LSE-68},
+}
+
+@DocuShare{LSE-69,
+  author =       {Gregory Dubois-Felsmann},
+  title =        {Interface between the Camera and Data Management},
+  year =         2014,
+  month =        oct,
+  handle =       {LSE-69},
+}
+
+@DocuShare{LSE-70,
+	author =	     {Paul Lotz},
+	title =		     {System Communication Protocol Interface},
+	year =		     2016,
+	month =		     sep,
+	handle =	     {LSE-70},
+}
+
+@DocuShare{LSE-72,
+  author =       {Gregory Dubious-Felsmann and German Schumacher and
+                  Brian Selvy},
+  title =        "{OCS Command Dictionary for Data Management}",
+  year =         2014,
+  month =        oct,
+  handle =       {LSE-72},
+}
+
+@DocuShare{LSE-75,
+  author =       {Gregory Dubious-Felsmann},
+  title =        "{Control System Interfaces between the Telescope and Data Management}",
+  year =         2011,
+  month =        aug,
+  handle =       {LSE-75},
+}
+
+@DocuShare{LSE-76,
+  author =       {Gregory Dubious-Felsmann},
+  title =        "{Infrastructure Interfaces between Summit Facility and Data Management}",
+  year =         2011,
+  month =        aug,
+  handle =       {LSE-76},
+}
+
+@DocuShare{LSE-77,
+  author =       {Gregory Dubious-Felsmann},
+  title =        "{Infrastructure Interfaces between Base Facility and Data Management}",
+  year =         2013,
+  month =        oct,
+  handle =       {LSE-77},
+}
+
+@DocuShare{LSE-78,
+	author =       {Ron Lambert and Jeff Kantor and Mike Huffer and Chip Cox
+                  and Paul Wefel and Matt Kollross and Sandra Jaque},
+	title =        { LSST Observatory Network Design},
+	year =         2017,
+	month =        apr,
+	handle =       {LSE-78},
+}
+
+@DocuShare{LSE-79,
+  author =       {Chuck Claver and {The LSST Commissioning Planning Team}},
+  title =        {System AI\&T and Commissioning Plan},
+  year =         2017,
+  month =        jan,
+  handle =       {LSE-79},
+}
+
+@DocuShare{LSE-81,
+  author =       {Gregory Dubois-Felsmann},
+  title =        {LSST Science and Project Sizing Inputs},
+  year =         2013,
+  month =        oct,
+  handle =       {LSE-81},
+}
+
+@DocuShare{LSE-82,
+  author =       {Gregory Dubois-Felsmann and Kian-Tat Lim},
+  title =        {Science and Project Sizing Inputs Explanation},
+  year =         2013,
+  month =        oct,
+  handle =       {LSE-82},
+}
+
+@DocuShare{LSE-130,
+  author =       {Gregory Dubois-Felsmann},
+  title =        "{Support-Data Exchanges between Data Management and Camera}",
+  year =         2015,
+  month =        jun,
+  handle =       {LSE-130},
+}
+
+@DocuShare{LSE-131,
+  author =       {Suzanne Jacoby and Ben Emmons and Brian Selvy},
+  title =        {Interface between Data Management and Education and
+                  Public Outreach},
+  year =         2017,
+  month =        jul,
+  handle =       {LSE-131},
+}
+
+@DocuShare{LSE-140,
+  author =       {Gregory Dubois-Felsmann},
+  title =        "{Auxiliary Instrumentation Interface between Data Management and Telescope}",
+  year =         2016,
+  month =        jul,
+  handle =       {LSE-140},
+}
+
+@DocuShare{LSE-159,
+  author =       {George Angeli},
+  title =        "{Reviews Definitions, Guidelines, and Procedures}",
+  year =         2013,
+  month =        sep,
+  handle =       {LSE-159},
+}
+
+@DocuShare{LSE-163,
+  author =       {Mario Juri\'c and others},
+  title =        {LSST Data Products Definition Document},
+  year =         2017,
+  month =        apr,
+  handle =       {LSE-163},
+}
+
+@DocuShare{LSE-180,
+  author =       {Lynne Jones},
+  title =        {Level 2 Photometric Calibration for the LSST Survey},
+  year =         2013,
+  month =        nov,
+  handle =       {LSE-180},
+}
+
+@DocuShare{LSE-209,
+	author =	     {Paul Lotz},
+	title =	 	     {Software Component to OCS Interface},
+	year =		     2016,
+	month =		     oct,
+	handle =	     {LSE-209},
+}
+
+@DocuShare{LSE-279,
+	author =	     {Alex Withers},
+	title =	 	     "{Concept of Operations for Unified LSST Authentication and Authorization Services}",
+	year =		     2017,
+	month =		     jan,
+	handle =	     {LSE-279},
+}
+
+@DocuShare{LSE-319,
+  author =       {M. Juri\'c and D. Ciardi and G.P. Dubois-Felsmann},
+  title =        {LSST Science Platform Vision Document},
+  year =         2017,
+  month =        jun,
+  handle =       {LSE-319},
+}
+
+@DocuShare{LTS-206,
+  author =       {D. Neill and J. Sebag and W. Gressler},
+  title =        "{Hexapods and Rotator Specifications Document}",
+  year =         2017,
+  handle =       {LTS-206},
+}
+
+@DocuShare{Report-142,
+  author =       {Tim Jenness and John Swinbank and Simon Krughoff and
+                  Gregory Dubois-Felsmann and David Ciardi},
+  title =        {Hot-Wiring the Transient Universe IV},
+  year =         2015,
+  month =        jun,
+  handle =       {Report-142},
+  note =         {Report on the Hot-Wiring the Transient Universe IV
+                  conference held in Santa Barbara in May 2015.},
+}
+
+@DocuShare{Report-241,
+  author =       {{LSST Project Science Team}},
+  title =        {Camera Mixed Focal Plane Option},
+  year =         2015,
+  month =        nov,
+  handle =       {Report-241},
+}
+
+@DocuShare{DMTN-007,
+  author = {David Reiss},
+   title = "{Dipole characterization for image differencing}",
+    year = 2016,
+  handle = {DMTN-007},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-007.lsst.io},
+}
+
+@DocuShare{DMTN-010,
+  author = {John Parejko and Russell Owen},
+   title = "{WCS and Distortion Requirements and Existing Options}",
+    year = 2016,
+  handle = {DMTN-010},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-010.lsst.io},
+}
+
+@DocuShare{DMTN-015,
+  author = {Jim Bosch},
+   title = "{Flavors of Coadds}",
+    year = 2016,
+  handle = {DMTN-015},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-015.lsst.io},
+}
+
+@DocuShare{DMTN-020,
+  author =       {Jacek Becla and Frossie Economou and Margaret Gelman and
+                  Jeff Kantor and Simon Krughoff and Kevin Long and Fritz
+                  Mueller and John Swinbank and Xiuqin Wu},
+  title =        {Project Management Guide},
+  year =         2016,
+  month =        nov,
+  handle =       {DMTN-020},
+  url =          {https://dmtn-020.lsst.io/}
+}
+
+@DocuShare{DMTN-021,
+  author = {David J. Reiss and Robert H. Lupton},
+   title = "{Implementation of Image Difference Decorrelation}",
+    year = 2016,
+  handle = {DMTN-021},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-021.lsst.io},
+}
+
+@DocuShare{DMTN-035,
+  author = {Mario Juri\'c and Andrew Becker and Richard Shaw and
+            K. Simon Krughoff and Jeff Kantor},
+   title = "{Winter 2013 LSST DM Data Challenge Release Notes}",
+    year = 2016,
+  handle = {DMTN-035},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-035.lsst.io},
+}
+
+@DocuShare{DMTN-037,
+  author = {Ian Sullivan},
+   title = "{DCR-matched template generation}",
+    year = 2017,
+  handle = {DMTN-037},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-037.lsst.io},
+}
+
+@DocuShare{DMTN-044,
+  author = {John D. Swinbank},
+   title = "{LSST DM Software Release Considerations}",
+    year = 2017,
+  handle = {DMTN-044},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-044.lsst.io},
+}
+
+@DocuShare{DMTN-046,
+  author = {Jacek Becla and Kian-Tat Lim and Daniel Wang},
+   title = "{An investigation of database technologies}",
+    year = 2013,
+  handle = {DMTN-046},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-046.lsst.io},
+}
+
+@DocuShare{DMTN-047,
+  author = {Jim Tommaney and Jacek Becla and Kian-Tat Lim and Daniel Wang},
+   title = "{Tests with InfiniDB}",
+    year = 2011,
+  handle = {DMTN-047},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-047.lsst.io},
+}
+
+@DocuShare{DMTN-048,
+  author = {Jacek Becla and Kian-Tat Lim and Daniel Wang},
+   title = "{Qserv design prototyping experiments}",
+    year = 2011,
+  handle = {DMTN-048},
+    note = {LSST Data Management Technical Note},
+     url = {https://dmtn-048.lsst.io},
+}
+
+@DocuShare{DMTR-11,
+  author = {Frossie Economou and John Swinbank and Jim Bosch
+            and Simon Krughoff},
+   title = "{Characterization Metric Report: Science Pipelines Version 11.0 (Summer 2015)}",
+    year = 2015,
+   month = oct,
+  handle = {DMTR-11},
+}
+
+@DocuShare{DMTR-12,
+  author = {Jacek Becla},
+   title = "{Qserv 300 node test}",
+    year = 2013,
+  handle = {DMTR-12},
+}
+
+@DocuShare{DMTR-13,
+  author = {Jacek Becla},
+   title = "{Qserv Summer 15 Large Scale Tests}",
+    year = 2015,
+   month = aug,
+  handle = {DMTR-13},
+}
+
+@DocuShare{DMTR-14,
+  author = {John Swinbank and Jim Bosch
+            and Simon Krughoff},
+   title = "{Characterization Metric Report: Science Pipelines Version 12.0}",
+    year = 2016,
+   month = mar,
+  handle = {DMTR-14},
+}
+
+@DocuShare{DMTR-15,
+  author = {Michael Wood-Vasey and John Swinbank},
+   title = "{Characterization Metric Report: Science Pipelines Version 13.0}",
+    year = 2017,
+   month = mar,
+  handle = {DMTR-15},
+}
+
+@DocuShare{DMTR-16,
+  author = {Vaikunth~Thukral},
+   title = "{Qserv Fall 16 Large Scale Tests/KPMs}",
+    year = 2017,
+   month = may,
+  handle = {DMTR-16},
+}
+
+@DocuShare{DMTR-21,
+  author = {Jacek Becla and K-T Lim and Daniel Wang},
+   title = "{Early (pre-2013) Large-Scale Qserv Tests}",
+    year = 2013,
+   month = aug,
+  handle = {DMTR-21},
+}
+
+@DocuShare{DMTR-22,
+  author = {K. Suberlak and {\v Z}. Ivezi\'c and {The PDAC Team}},
+   title = "{Prototype Data Access Center: User Report}",
+    year = 2017,
+   month = jul,
+  handle = {DMTR-22},
+}
+
+@DocuShare{SQR-018,
+  author = {Frossie Economou},
+   title = "{Investigations into JupyterLab as a basis for the LSST Science Platform}",
+    year = 2017,
+   month = jun,
+  handle = {SQR-018},
+     url = {https://sqr-018.lsst.io},
+}

--- a/{{cookiecutter.repo_name}}/lsstbib/refs.bib
+++ b/{{cookiecutter.repo_name}}/lsstbib/refs.bib
@@ -1,0 +1,2124 @@
+% General reference not found in ADS
+% Do not put books in this file
+%
+
+@ARTICLE{1991.Spyak.OpticalEngineering,
+  author =       {{Spyak}, P.R. and {Wolfe}, W.L.},
+  title =        "{Scatter from particulate-contaminated mirrors}",
+  journal =      {Optical Engineering},
+  year =         1991,
+  volume =       31,
+  pages =        {1746-1784}
+}
+
+@ARTICLE{1997.Fornies-Marquina.IEEE,
+  author =       {{Fornies-Marquina}, J.M. and {Letosa}, J. and
+                  {Garc{\'\i}a-Gracia}, M. and {Artacho}, J.M.},
+  title =        "{Error propagation for the transformation of time
+                  domain into frequency domain}",
+  journal =      {IEEE transactions on magnetics},
+  year =         1997,
+  month =        mar,
+  volume =       33,
+  pages =        {1456-1459}
+}
+
+@ARTICLE{2003.Holland.IEEE,
+  author =       {{Holland}, S. E. and {Groom}, D. E. and {Palaio},
+                  N. P. and {Stover}, R. J.  and {Wei}, M.},
+  title =        "{Fully depleted, back-illuminated charge-coupled
+                  devices fabricated on high-resistivity silicon}",
+  journal =      {IEEE transactions on electron devices},
+  year =         2003,
+  month =        jan,
+  volume =       50,
+  pages =        {225-238}
+}
+
+% 2003AJ....125.1580Ka is in  gaia_refs_ads as it should be,
+
+@ARTICLE{2005.Baccaro.IEEE,
+  author =       {{Baccaro}, S. and {Piegari}, A. and {Di Sarcina},
+                  I. and {Cecilia}, A.},
+  title =        "{Effect of Irradiation on Optical Components}",
+  journal =      {IEEE transactions on nuclear science},
+  year =         2005,
+  month =        oct,
+  volume =       52,
+  pages =        {1779-1784}
+}
+
+@INPROCEEDINGS{2008ASSL..349..399K,
+  author =       {{Klioner}, S.~A.},
+  title =        "{Testing Relativity with Space Astrometry Missions}",
+  booktitle =    {Lasers, Clocks and Drag-Free Control: Exploration of
+                  Relativistic Gravity in Space},
+  year =         2008,
+  series =       {Astrophysics and Space Science Library},
+  volume =       349,
+  editor =       "{H.~Dittus, C.~Lammerzahl, \& S.~G.~Turyshev}",
+  pages =        399,
+  doi =          {10.1007/978-3-540-34377-6_19},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008ASSL..349..399K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010.Seabroke.SPIE,
+  author =       { Seabroke, G. M. and Holland, A. D. and Burt, D. and
+                  Robbins, M. S.},
+  title =        "{Silvaco ATLAS model of ESA's Gaia satellite e2v
+                  CCD91-72 pixels}",
+  journal =      {Proc. SPIE},
+  year =         2010,
+  volume =       7742,
+  pages =        {774-14}
+}
+
+@ARTICLE{2010arXiv1002.5016K,
+  author =       {{Klioner}, S.~A. and {Zschocke}, S. and {Soffel},
+                  M.~H. and {Butkevich}, A.~G.},
+  title =        "{Testing Local Lorentz Invariance with high-accuracy
+                  astrometric observations}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1002.5016},
+  primaryClass = "astro-ph.CO",
+  keywords =     {Astrophysics - Cosmology and Extragalactic
+                  Astrophysics},
+  year =         2010,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2010arXiv1002.5016K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012.Vuillermet.SPIE,
+  author =       {Vuillermet, M. and Billon-Lanfrey, D. and Reibel,
+                  Y. and Manissadjian, A. and Mollard, L. and Baier,
+                  N. and Gravrand, O. and Destéfanis G.},
+  title =        "{Status of MCT focal plane arrays in France}",
+  journal =      {Proc. SPIE 8353, Infrared Technology and
+                  Applications XXXVIII},
+  year =         2012,
+  month =        may,
+  volume =       38,
+  pages =        83532,
+  doi =          {10.1117/12.921868},
+}
+
+@ARTICLE{Ana:AgisCg,
+  author =       {A.~Bombrun and L.~Lindegren and D.~Hobbs and B.~Holl
+                  and U.~Lammers and U.~Bastian},
+  title =        {A conjugate gradient algorithm for the astrometric
+                  core solution of {Gaia}},
+  journal =      {Astronomy and Astrophysics},
+  year =         2012,
+  month =        {February},
+  volume =       538,
+  note =         {A77},
+  doi =          {10.1051/0004-6361/201117904},
+}
+
+@ARTICLE{Ana:AgisMain,
+  author =       { L.~Lindegren and U.~Lammers and D.~Hobbs and
+                  W.~O'Mullane and U.~Bastian and J.~Hernandez},
+  title =        {The astrometric core solution for the {Gaia}
+                  mission. {Overview} of models, algorithms, and
+                  software implementation},
+  journal =      {Astronomy and Astrophysics},
+  year =         2012,
+  month =        {February},
+  volume =       538,
+  note =         {A78},
+  doi =          {10.1051/0004-6361/201117905},
+}
+
+@TechReport{CU6:AG-003,
+  author =       {A.~Guerrier},
+  title =        {{S}oftware {D}esign {D}ocument for {W}avelength
+                  {C}alibration},
+  institution =  {ESA},
+  note =         {GAIA-C6-TN-OPM-AG-003-1}
+}
+
+@TechReport{CU6:AG-004,
+  author =       {A.~Guerrier},
+  title =        {{S}oftware {D}esign {D}ocument for {A}pply
+                  {C}alibration},
+  institution =  {ESA},
+  note =         {GAIA-C6-SP-OPM-AG-004-1}
+}
+
+@TechReport{DOC:HEH-001,
+  author =       {H.~Huckle},
+  year =         2007,
+  institution =  {ESA},
+  title =        {Continuum {N}ormalisation},
+  note =         {GAIA-C6-SP-MSSL-HEH-001-D}
+}
+
+@article{Fraedrich:2009:TMV,
+  author =       {Roland Fraedrich and Jens Schneider and R\"{u}diger
+                  Westermann},
+  title =        {Exploring the "Millennium Run" - Scalable Rendering
+                  of Large-Scale Cosmological Datasets},
+  year =         2009,
+  month =        {November-December},
+  journal =      {IEEE Transactions on Visualization and Computer
+                  Graphics (Proceedings Visualization / Information
+                  Visualization 2009)},
+  volume =       15,
+  number =       6,
+  pages =        {to appear},
+  doi =          {xx.xxxx/xxxxxxx.xxxxxxx},
+}
+
+@TechReport{GAIA.ASF.SP.PLM.00174,
+  author =       {{EADS~Astrium}},
+  title =        {GAIA PLM TB/TV test specification: functional and
+                  performance tests},
+  institution =  {ESA},
+  year =         2010,
+  month =        {June},
+  note =         {GAIA.ASF.SP.PLM.00174}
+}
+
+@TechReport{GAIA.ASU.TCN.ESM.00153,
+  author =       {{EADS~Astrium}},
+  title =        {Gaia Attitude- and Orbit-Control sub-System Normal
+                  Mode Final Tuning and Stability Analysis},
+  institution =  {ESA},
+  year =         2011,
+  month =        {July},
+  note =         {GAIA.ASU.TCN.ESM.00153}
+}
+
+@TechReport{GAIASYS.NT.00134.T.ASTR,
+  author =       {{EADS~Astrium}},
+  title =        {GAIA Point Spread Function and internal straylight
+                  evaluation},
+  institution =  {ESA},
+  year =         2004,
+  month =        {February},
+  note =         {GAIASYS.NT.00134.T.ASTR}
+}
+
+@Article{IAU:2001,
+  author =       {IAU},
+  title =        {},
+  journal =      {{I}nformation {B}ulletin},
+  volume =       88,
+  year =         2001,
+  note =         {(errata in IAU Information Bulletin, 89)}
+}
+
+@article{LLGaiaStatus,
+  author =       {Lindegren,Lennart},
+  title =        {Gaia: Astrometric performance and current status of
+                  the project},
+  journal =      {Proceedings of the International Astronomical Union},
+  volume =       5,
+  number =       {Symposium S261},
+  pages =        {296-305},
+  year =         2009,
+  doi =          {10.1017/S1743921309990548},
+}
+
+
+@LiveLink{ecss:projectbs,
+  author =  { {ESA Publications Division}},
+  title =   { {P}roject {B}reakdown {S}tructures },
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2003,
+  month =   {June},
+  livelinknumber =    {ECSS-M-10B},
+  livelinkshortnumber =    {ECSS-M-10B}
+}
+
+@LiveLink{ecss:e10,
+  author =  { {ESA Publications Division}},
+  title =   { {F}unctional and {T}echnical {S}pecifications },
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2003,
+  month =   {June},
+  livelinknumber =    {ECSS-E-10 part 6a},
+  livelinkshortnumber =    {ECSS-E-10-6a}
+}
+
+@LiveLink{ecss:pa,
+  author =  { {ESA Publications Division}},
+  title =   { {S}oftware {P}roduct {A}ssurance },
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2003,
+  month =   {June},
+  livelinknumber =    {ECSS-Q-80B},
+  livelinkshortnumber =    {ECSS-Q-80B}
+}
+
+@LiveLink{ecss:spmdoc,
+  author =  { {ESA Publications Division}},
+  title =   { {S}pace {P}roject {M}anagent - configuration management },
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2003,
+  month =   {June},
+  livelinknumber =    {ECSS-M-40B },
+  livelinkshortnumber =    {ECSS-M-40B }
+}
+
+@LiveLink{ecss:spmdoc50B,
+  author =  { {ESA Publications Division}},
+  title =   { {S}pace {P}roject {M}anagent - information/documentation management },
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2003,
+  month =   {June},
+  livelinknumber =    {ECSS-M-50B Draft 8},
+  livelinkshortnumber =    {ECSS-M-50B}
+}
+
+@LiveLink{ecss:projectorg,
+  author =  { {ESA Publications Division}},
+  title =   { {P}roject {O}rganisation },
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2003,
+  month =   {June},
+  livelinknumber =    {ECSS-M-20B},
+  livelinkshortnumber =    {ECSS-M-20B}
+}
+
+@LiveLink{ecss:projectphaseplan,
+  author =  { {ESA Publications Division} },
+  title =   { {P}roject {P}hasing and {P}lanning },
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2003,
+  month =   {June},
+  livelinknumber =    {ECSS-M-30B},
+  livelinkshortnumber =    {ECSS-M-30B}
+}
+
+@LiveLink{ecss:organizationandconductofreviews,
+  author =  { {ESA Publications Division}},
+  title =   { {O}rganization and  {C}onduct of {R}eviews },
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    1999,
+  month =   {September},
+  livelinknumber =    {ECSS-M-30-01A},
+  livelinkshortnumber =    {ECSS-M-30-01A}
+}
+
+
+@LiveLink{ecss:tailoring,
+  author =  { {ESA Publications Division}},
+  title =   { {P}roject {O}rganisation },
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2000,
+  month =   {April},
+  livelinknumber =    {ECSS-M-00-02A},
+  livelinkshortnumber =    {ECSS-M-00-02A}
+}
+
+@LiveLink{ecss:swreq,
+  author =  { {ESA Publications Division}},
+  title =   { {S}pace enginneering - {S}oftware - {P}art 1: {P}rinciples and
+requirements},
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2003,
+  month =   {November},
+  livelinknumber =    {ECSS-E-40 Part 1B},
+  livelinkshortnumber =    {ECSS-E-40-1B}
+}
+
+@LiveLink{ecss:planimplement,
+  author =  { {ESA Publications Division}},
+  title =   { {S}pace project management  - {P}roject planning and implementation},
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2008,
+  month =   {July},
+  livelinknumber =    {ECSS-M-ST-10C},
+  livelinkshortnumber =    {ECSS-M-ST-10C}
+}
+
+@LiveLink{ecss:costschedule,
+  author =  { {ESA Publications Division}},
+  title =   { {S}pace project management  - {C}ost and schedule management},
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2008,
+  month =   {July},
+  livelinknumber =    {ECSS-M-ST-60C},
+  livelinkshortnumber =    {ECSS-M-ST-60C}
+}
+
+@LiveLink{ecss:docreq,
+  author =  { {ESA Publications Division}},
+  title =   { {S}pace enginneering - {S}oftware - {P}art 2: {D}ocument
+{R}equirements {D}efinitions},
+  institution = { {E}uropean {C}ooperation for {S}pace {S}tandardization },
+  year =    2005,
+  month =   {March},
+  livelinknumber =    {ECSS-E-40 Part 2B},
+  livelinkshortnumber =    {ECSS-E-40-2B}
+}
+
+@LiveLink{cnes:sec,
+  author= {Jean-Charles Valadier },
+  title  =  {Etude de risque EBIOS du systme CNES-DPC (Limited distribution)},
+  institution = { CNES },
+  year =    2008,
+  month =   {February},
+  livelinknumber =    {Gaia-NT-32000-115-CNES},
+  livelinkshortnumber =    {Gaia-NT-32000-115-CNES}
+}
+
+@LiveLink{esa:sec,
+  author= {Christoph Krall},
+  title  =  {IMPLEMENTATION OF THE ESA NETWORK SECURITY POLICY},
+  institution = { {E}uropean {S}pace {A}gency },
+  year =    2004,
+  month =   {September},
+  livelinknumber =    {EISD-EPNS-00003},
+  livelinkshortnumber =    {EISD-EPNS-00003}
+}
+
+@TechReport{Lindegren1993,
+  author =       {Lennart Lindegren and Michael Perryman et al },
+  title =        { GAIA : Global Astrometric Interferometer for
+                  Astrophysics },
+  institution =  { Lund },
+  year =         1993,
+  month =        {October},
+  url =
+                  {http://www.astro.lu.se/\%7Elennart/Astrometry/gaia_proposal.PDF}
+}
+
+@TechReport{NGST.BRDF.Lallo,
+  year =         1999,
+  author =       {{{Lallo}, M. and {Petro}, L.}},
+  title =        {Bidirectional reflectance distribution function for
+                  the NGST mirrors},
+  institution =  {Space Telescope Science Institute},
+  month =        {February},
+}
+
+@TechReport{REC-ADQL-2.0,
+  author =       { Ortiz I., Lusted J., Dowler P. },
+  title =        { Astronomical Data Query Language },
+  institution =  { IVOA },
+  year =         2008,
+  month =        {October},
+  note =         {REC-ADQL-2.0}
+}
+
+@TechReport{REC-SSO-1.01,
+  author =       { Rixon G., Graham M. },
+  title =        { Single-Sign-On Profile: Authentication Mechanisms },
+  institution =  { IVOA },
+  year =         2008,
+  month =        {January},
+  note =         {REC-SSO-1.01}
+}
+
+@TechReport{REC-TAP-1.0,
+  author =       { Dowler P., Rixon G., Tody D. },
+  title =        { Table Access Protocol },
+  institution =  { IVOA },
+  year =         2010,
+  month =        {March},
+  note =         {REC-TAP-1.0}
+}
+
+@TechReport{REC-UWS-1.0,
+  author =       { Harrison P., Rixon G. },
+  title =        { Universal Worker Service Pattern },
+  institution =  { IVOA },
+  year =         2010,
+  month =        {October},
+  note =         {REC-UWS-1.0}
+}
+
+@TechReport{REC-VOSpace-1.15,
+  author =       { Graham M., Morris D., Rixon G. },
+  title =        { VOSpace specification },
+  institution =  { IVOA },
+  year =         2009,
+  month =        {October},
+  note =         {REC-VOSpace-1.15}
+}
+
+@TechReport{REC-VOSpace-2.0,
+  author =       { Graham M., Morris D., Rixon G. },
+  title =        { VOSpace specification },
+  institution =  { IVOA },
+  year =         2011,
+  month =        {June},
+  note =         {REC-VOSpace-2.0}
+}
+
+@INPROCEEDINGS{Schneider-2005:a,
+  author =       {{Schneider}, J.},
+  title =        "{Can the Perturbation of a Stellar Motion in a
+                  Triple System Mimic a Planet}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {263--266}
+}
+
+@misc{WS2CU6:extraction,
+  author =       {M.~Cropper and S.R.~Rosen},
+  title =        { Spectra Extraction},
+  note =         {{CU6 W}orkshop2},
+  year =         2006,
+  url =          {http://wwwhip.obspm.fr/gaia/cu6/workshop_2/CU6_w2_Cropper_extraction.pdf},
+}
+
+@misc{WS2CU6:intro,
+  author =       {D.~Katz},
+  title =        { {G}aia - {RVS}: {DPAC} and {CU6}},
+  note =         {{CU6 W}orkshop2},
+  year =         2006,
+  url =          {http://wwwhip.obspm.fr/gaia/cu6/workshop_2/CU6_w2_Katz_intro.pdf},
+}
+
+@ARTICLE{bucc1,
+  author =       {{Bucciarelli}, B. and {Taff}, L.~G. and {Lattanzi},
+                  M.~G.},
+  title =        "{A generalization of the moving mean}",
+  year =         1993,
+  journal =      {J. Statist. Comput. Simul.},
+  volume =       48,
+  pages =        29
+}
+
+@TechReport{ccsds:packettelemetry,
+  author =       {Unknown},
+  title =        {Packet Telemetry, {B}lue {B}ook},
+  institution =  {Consultative Committee for Space Data Systems},
+  year =         2000,
+  month =        {November},
+  note =         {CCSDS 102.0-B-5, {\tt
+                  http://www.ccsds.org/documents/102x0b5.pdf}}
+}
+
+@TechReport{ccsds:timecodeformats,
+  author =       {Unknown},
+  title =        {Time Code Formats, {B}lue {B}ook},
+  institution =  {Consultative Committee for Space Data Systems},
+  year =         2002,
+  month =        {January},
+  note =         {CCSDS 301.0-B-3, {\tt
+                  http://www.ccsds.org/documents/301x0b3.pdf}}
+}
+
+@TechReport{ccsds:tmchannelcoding,
+  author =       {Unknown},
+  title =        {Telemetry Channel Coding, {B}lue {Book}},
+  institution =  {Consultative Committee for Space Data Systems},
+  year =         2002,
+  month =        {October},
+  note =         {CCSDS 101.0-B-6, {\tt
+                  http://www.ccsds.org/documents/101x0b6.pdf}}
+}
+
+@TechReport{ccsds:tmconcept,
+  author =       {Unknown},
+  title =        {Telemetry Summary of Concept and Rationale, {G}reen
+                  {Book}},
+  institution =  {Consultative Committee for Space Data Systems},
+  year =         1987,
+  month =        {December},
+  note =         {CCSDS 100.0-G-1, {\tt
+                  http://www.ccsds.org/documents/100x0g1.pdf}}
+}
+
+@TechReport{compressoracle10g,
+  author =       { Oracle },
+  title =        { Data Compression in 10g },
+  institution =  { Oracle Corporation },
+  year =         2005,
+  month =        {May},
+  url =          {http://www.oracle.com/technology/products/bi/db/10g/pdf/twp_data_compression_10gr2_0505.pdf},
+}
+
+@TechReport{compressoracle11g,
+  author =       { Oracle },
+  title =        { Data Compression in 11g },
+  institution =  { Oracle Corporation },
+  year =         2007,
+  month =        {May},
+  url =          {http://download.oracle.com/docs/cd/B28359_01/server.111/b28318/schema.htm#CNCPT1132},
+}
+
+@TechReport{conf:casjobs,
+institution = {Microsoft},
+note = {Microsoft Technical Report MSR TR 2005 19},
+author = {{OMullane}, W. and {Li}, N. and {Nieto-Santisteban}, M. and
+          {Szalay}, A. and {Thakar}, A. and {Gray}, J.},
+ title = "{Batch is back: CasJobs, serving multi-TB data on the Web}",
+journal = {eprint arXiv:cs/0502072},
+eprint = {cs/0502072},
+keywords = {Computer Science - Distributed, Parallel, and Cluster Computing, Computer Science - Databases},
+  year = 2005,
+ month = feb,
+adsurl = {http://adsabs.harvard.edu/abs/2005cs........2072O},
+adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@Inproceedings{conf:monterosa,
+  author =       { S.~G.~Ansari and J.~Torra and X.~Luri and
+                  F.~Figueras and C.~Jordi and E.~Masana },
+  title =        { {Gaia} {Spectroscopy} },
+  booktitle =    { {Science} and {Technology}, {ASP} {Conference}
+                  {Series} },
+  volume =       { 298 },
+  year =         { 2003 },
+  month =        { September },
+  note =         { page 97 }
+}
+
+@inproceedings{doi:10.1117/12.2233380,
+   author = {{Kantor}, J. and {Long}, K. and {Becla}, J. and {Economou}, F. and
+	{Gelman}, M. and {Juric}, M. and {Lambert}, R. and {Krughoff}, S. and
+	{Swinbank}, J.~D. and {Wu}, X.},
+    title = "{Agile software development in an earned value world: a survival guide}",
+booktitle = {Modeling, Systems Engineering, and Project Management for Astronomy VI},
+     year = 2016,
+   series = {\procspie},
+   volume = 9911,
+    month = aug,
+      eid = {99110N},
+    pages = {99110N},
+      doi = {10.1117/12.2233380},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9911E..0NK},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@inproceedings{doi:10.1117/12.2233619,
+   author = {{Vagg}, D. and {O'Callaghan}, D. and {O'H{\'o}g{\'a}in}, F. and
+	{McBreen}, S. and {Hanlon}, L. and {Lynn}, D. and {O'Mullane}, W.
+	},
+    title = "{GAVIP: a platform for Gaia data analysis}",
+booktitle = {Software and Cyberinfrastructure for Astronomy IV},
+     year = 2016,
+   series = {\procspie},
+   volume = 9913,
+archivePrefix = "arXiv",
+   eprint = {1605.09287},
+ primaryClass = "astro-ph.IM",
+    month = jul,
+      eid = {99131V},
+    pages = {99131V},
+      doi = {10.1117/12.2233619},
+   adsurl = {http://adsabs.harvard.edu/abs/2016SPIE.9913E..1VV},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@TechReport{esa:javastandard,
+  author =       {ESA Board for Software Standarisation and Control},
+  title =        {Java Coding Standards},
+  institution =  {ESA},
+  year =         2004,
+  url = {http://www.rssd.esa.int/llink/livelink/Java_coding_standards.pdf?func=doc.Fetch&nodeId=504569&docTitle=Java+coding+standards&vernum=1},
+}
+
+@TechReport{esa:sogs,
+  author =       {D.~Texier},
+  title =        {Note on Science Operations Ground Segment
+                  Documentation},
+  institution =  {ESA},
+  year =         2005,
+  note =         { SOGS-TN-ESAC-DT-001 }
+}
+
+@TechReport{esoc:sgicdvol1,
+  author =       {R.~Furnell},
+  title =        {{G}aia {S}pace/{G}round {I}nterface {C}ontrol
+                  {D}ocument {V}olume 1: {RF} {I}nterface},
+  institution =  {ESA/ESOC},
+  year =         2005,
+  month =        {April},
+  note =         {GAIA-ESC-ICD-515}
+}
+
+@TechReport{esoc:sgicdvol2,
+  author =       {R.~Furnell},
+  title =        {{G}aia {S}pace/{G}round {I}nterface {C}ontrol
+                  {D}ocument {V}olume 2: {G}eneric {P}acket
+                  {S}tructure},
+  institution =  {ESA/ESOC},
+  year =         2005,
+  month =        {April},
+  note =         {GAIA-ESC-ICD-516}
+}
+
+@PHDTHESIS{crosta03,
+  author =       {{Crosta}, M.~T.},
+  title =        "{Methods of Relativistic Astrometry for the analysis
+                  of astrometric data in the Solar System
+                  gravitational field}",
+  year =         2003,
+  school =       {Universit\`a di Padova},
+}
+
+@ARTICLE{eyer1998,
+  author =       {{Eyer}, L.},
+  title =        "{Les \'etoiles variables de la mission {HIPPARCOS}}",
+  journal =      {Ph.D.~Thesis},
+  year =         1998,
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1998PhDT.........8E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@TechReport{gaia:AstroFPAGenDesign,
+  author =       { Astrium GAIA FPA team },
+  title =        { {GAIA} {CCD} and {F}ocal {P}lan {T}echnology
+                  {D}emonstrators: {ASTRO} {FPA} {G}eneral {D}esign
+                  {Description} },
+  institution =  { EADS/Astrium },
+  year =         2003,
+  month =        {December},
+  note =         {GAIAFPA.NT.00120.T.ASTR}
+}
+
+@Misc{gaia:DATATAG,
+  key =          {DataTag},
+  title =        {DataTag, Research \& technological development for a
+                  Data TransAtlantic Grid,
+                  http://datatag.web.cern.ch/datatag/project.html},
+  text =         {DataTag, Research \& technological development for a
+                  Data TransAtlantic Grid,
+                  http://datatag.web.cern.ch/datatag/project.html},
+  url =          {http://datatag.web.cern.ch/datatag/project.html}
+}
+
+@Misc{gaia:GRIDFTP,
+  key =          {GRIDFTP},
+  title =        {Universal Data Transfer for the Grid,
+                  http://www-fp.globus.org/datagrid/deliverables/C2WPdraft3.pdf},
+  text =         {Universal Data Transfer for the Grid,
+                  http://www-fp.globus.org/datagrid/deliverables/C2WPdraft3.pdf},
+  year =         2005,
+  month =        {September},
+  url =
+                  {http://www-fp.globus.org/datagrid/deliverables/C2WPdraft3.pdf}
+}
+
+@TechReport{gaia:NOSTFITS,
+  author =       {{NASA/Science Office of Standards and Technology}},
+  title =        {{Definition of the Flexible Image Transport System
+                  (FITS)}},
+  institution =  {NASA/NOST},
+  year =         1995,
+  number =       {NOST 100-1.1},
+  month =        {September}
+}
+
+@Article{gaia:UDTICD,
+  author =       {R.~Grossman and Y.~Gu and X.~Hong and A.~Antony and
+                  J.~Blom and F.~Dijkstra and C.~de~Laat},
+  title =        {Teraflows over Gigabit WANs with UDT},
+  journal =      {Future Generation Computer Systems},
+  doi =          {10.1016/j.future.2004.10.007},
+  year =         2004,
+  pages =        501,
+  volume =       21,
+}
+
+@Misc{gaia:acronyms,
+  key =          {Gaia Acronyms},
+  note =         {{G}aia {A}cronyms {L}ist},
+  url =          {http://www.rssd.esa.int/Ageneral/Projects/GAIA/paramdb/glossary.txt},
+}
+
+@TechReport{gaia:astriumdefstudy,
+  author =       { EADS Astrium Gaia team },
+  title =        { {GAIA} {D}efinition {S}tudy },
+  institution =  { EADS/Astrium },
+  year =         2005,
+  month =        {June},
+  note =         {Final Presentation, Noordwijk, June 8, 2005}
+}
+
+@TechReport{gaia:astriumreass,
+  author =       {Astrium SLTRS project team},
+  title =        {{G}aia {S}ystem {L}evel {T}echnical {R}eassessment
+                  {S}tudy},
+  institution =  {EADS Astrium},
+  year =         2002,
+  month =        {June},
+  note =         {EF5/FR/PC/038.02}
+}
+
+@TechReport{gaia:bprpoptimization,
+  author =       {C.~Jordi and E.~H{\o}g and A.~G.~A.~Brown and
+                  J.~de~Bruijne},
+  title =        {Gaia spectrophometers: optimization study},
+  year =         2006,
+  month =        {April},
+  institution =  {ESA},
+  note =         {GAIA-CH-TN-UB-CJ-037}
+}
+
+@TechReport{gaia:crema,
+  author =       {M.~Hechler},
+  title =        {{G}AIA {C}onsolidated {R}eport on {M}ission
+                  {A}nalysis {(CReMA)}},
+  institution =  {ESA, European Space Operations Cenre},
+  year =         2006,
+  month =        {March},
+  note =         {GAIA-ESC-RP-0001, Issue 2.0}
+}
+
+@TechReport{gaia:e2vccddesignreport,
+  author =       { D.~Burt },
+  title =        { Gaia {T}echnology {D}emonstrator: {AF} {CCD}
+                  {DESIGN} {REPORT} },
+  institution =  { e2v },
+  year =         2003,
+  month =        {January},
+  note =         {GAIA-E2V-RP-020}
+}
+
+@Misc{gaia:elevreductcalc,
+  author =       {U. Lammers},
+  note =         {unpublished results - see also
+                  \url{http://www.rssd.esa.int/\-GAIA/\-PoW\_ground\_station\_visibility.html}}
+}
+
+@Misc{gaia:elevreductesoc,
+  author =       {M. Hechler},
+  note =         {ESOC, private communication},
+  month =        apr,
+  year =         2004,
+}
+
+@Misc{gaia:fmphaseangleopt,
+  author =       {F. Mignard},
+  note =         {Observatoire de la C\^{o}te
+                  D'Azur/CERGA, private communication},
+  month =        may,
+  year =         2004,
+}
+
+@InProceedings{gaia:gaiagrid,
+  author =       {S.~G.~Ansari and U.~Lammers and M.~ter~Linden },
+  title =        {GaiaGrid : Its Implications and Implementation},
+  year =         2005,
+  booktitle =    {Proc. Astronomical Data Analysis Software and
+                  Systems XIV},
+  volume =       347,
+  pages =        {429--},
+  publisher =    {Astronomical Society of the Pacific }
+}
+
+@TechReport{gaia:horizon2000,
+  author =       {L.~Lindegren and M.~A.~C.~Perryman and U.~Bastian
+                  and J.~C.~Dainty and E.~H{\o}g and F.~van~Leeuwen
+                  and J.~Kovalevsky and A.~Labeyrie and F.~Mignard and
+                  J.~E.~Noordam and R.~S.~Le~Poole and P.~Thejll and
+                  F.~Vakili},
+  title =        {GAIA: Global Astrometric Interferometer for
+                  Astrophysics},
+  institution =  {Lund Observatory},
+  year =         1993,
+  month =        {October},
+  note =         {Response to Call for Mission Concepts for Horizon
+                  2000 Follow UP: Proposal for an astrometric
+                  interferometer as an ESA Cornerstone Mission}
+}
+
+@TechReport{gaia:interfero,
+  author =       {L.~Lindegren and M.~A.~C.~Perryman},
+  title =        {A Small Interferometer in Space for Global
+                  Astrometry: the Gaia Concept},
+  institution =  {Lund Observatory},
+  year =         1994,
+  month =        {August},
+  note =         {IAU Symp. No 166, Astronomical and Astrophysical
+                  Objectives of sub-milliarcsecon Optical Astronomy,
+                  The Hague, 15--19 August 1994}
+}
+
+@Misc{gaia:joscarmepriv,
+  author =       {J. de~Bruijne and C. Jordi},
+  note =         {private communication},
+  year =         2004,
+  month =        may,
+  url =          {http://gaia.am.ub.es/PWG/common/instrumGAIA2.html},
+}
+
+@Misc{gaia:jospriv,
+  author =       {J. de~Bruijne},
+  note =         {private communication},
+  year =         2004,
+  month =        may,
+}
+
+@Misc{gaia:lattanzipriv,
+  author =       {M. Lattanzi and R. Drimmel},
+  note =         {private communcation},
+  year =         2003,
+  month =        oct,
+}
+
+@TechReport{gaia:llorbit,
+  author =       {F.~Mignard},
+  title =        {{C}onsiderations on the orbit of {G}aia for
+                  simulations},
+  institution =  {Observatoire de la C\^{o}te D'Azur/CERGA},
+  year =         2002,
+  month =        {March},
+  note =         {GAIA-FM-011}
+}
+
+@TechReport{gaia:mird,
+  author =       { {GAIA} Project Team },
+  title =        { {Gaia} {M}ission {I}mplementation {R}equirement
+                  {D}ocument },
+  year =         2006,
+  month =        {May},
+  institution =  {ESA},
+  note =         {{G}AIA-EST-RQ-00457}
+}
+
+@Misc{gaia:nu0opt,
+  author =       {U. Lammers},
+  note =         {unpublished results},
+}
+
+@Misc{gaia:pdbonline,
+  key =          {GPD},
+  note =         {{G}aia {P}arameter {D}atabase},
+  url =          {http://www.rssd.esa.int/Gaia/paramdb},
+}
+
+@TechReport{gaia:practscanlaw,
+  author =       {F.~Mignard},
+  title =        {A practical scanning law for {GAIA} simulations},
+  institution =  {CERGA},
+  year =         2001,
+  month =        {December},
+  note =         {GAIA-FM-010}
+}
+
+@TechReport{gaia:soderhjelm,
+  author =       {S.~Soderhjelm},
+  title =        {Theoretical modelling of observational double-star
+                  distribution functions.},
+  institution =  {ESA},
+  year =         2004,
+  note =         {DMS-SS-05}
+}
+
+@TechReport{gaia:spieconf,
+  author =       {L.~Lindegren and M.~A.~C.~Perryman and U.~Bastian
+                  and J.~C.~Dainty and E.~H{\o}g and F.~van~Leeuwen
+                  and J.~Kovalevsky and A.~Labeyrie and S.\~Loiseau
+                  and F.~Mignard and J.~E.~Noordam and R.~S.~Le~Poole
+                  and P.~Thejll and F.~Vakili},
+  title =        {GAIA: Global Astrometric Interferometer for
+                  Astrophysics},
+  institution =  {Lund Observatory},
+  year =         1994,
+  month =        {March},
+  note =         {Proc. of Astronomical Telescopes and Instrumentation
+                  for the 21st Century. Technical Conference 2200,
+                  SPIE Symposium in Kona, 13--18 March 1994}
+}
+
+@TechReport{gaia:srd,
+  author =       {G.~Colangelo},
+  title =        {{G}aia {S}ystem {R}equirements {D}ocument for
+                  {T}echnical {A}ssistance \& {D}efinition {P}hase},
+  institution =  {ESA},
+  year =         2004,
+  month =        {March},
+  note =         {Gaia-SRC-001, Issue 1.0}
+}
+
+@Misc{gaia:ssmobjattribs,
+  author =       {F. Arenou and F. Ch\'ereau},
+  note =         {private communication}
+}
+
+@TechReport{gaia:studyreport,
+  author =       {ESA},
+  title =        {{GAIA --- {C}omposition, {F}ormation and {E}volution
+                  of the {G}alaxy}},
+  year =         2000,
+  month =        {July},
+  institution =  {ESA},
+  note =         {Concept and Technology Study Report, ESA-SCI(2000)4}
+}
+
+@TechReport{gaia:surveycom,
+  author =       {L.~Lindegren and M.~A.~C.~Perryman},
+  title =        {GAIA: Global Astrometric Interferometer for
+                  Astrophysics},
+  institution =  {Lund Observatory},
+  year =         1994,
+  month =        {September},
+  note =         {Supplementary Information Submitted to the
+                  Horizon2000+ Survey Committee}
+}
+
+@TechReport{gaia:toolbox,
+  author =       {F.~De~Angeli},
+  title =        {The {G}aia {S}oftware {T}oolbox - {U}ser guide},
+  institution =  {IoA},
+  year =         2005,
+  url =          {http://www.rssd.esa.int/SA-general/Projects/GAIA/wiki/index.php?title=CU1:_GaiaTools},
+}
+
+@TechReport{gaia:ttcanal,
+  author =       { M.~Martinez Fernandez },
+  title =        { {G}aia {TT\&C} {S}ubsystem {A}nalysis },
+  year =         2005,
+  month =        {January},
+  institution =  {ESA},
+  note =         { Note prepared at request of Project team}
+}
+
+@misc{gdaas:algoicd,
+  author =       {S.~Ansari and J.~Torra and P.~P.~L\'opez and X.~Luri
+                  and I.~Serraller and Y.~Balague},
+  title =        {{A}lgorithm {I}nterface {C}ontrol {D}ocument},
+  institution =  {Confiuration Control Board},
+  note =         {CCB-GDAAS-ICD-001}
+}
+
+@misc{gdaas:algoprep,
+  author =       {C.~Fabricius and J.~Torra},
+  title =        {{GDAAS} {A}lgorithm {P}reparation {G}uidelines},
+  institution =  {GDAAS Configuration Conrol Board},
+  note =         {CCB-GDAAS-002}
+}
+
+@TechReport{gdaas:giscalib,
+  author =       {H.~Lenhardt},
+  title =        {{GIS} implementation in {GDAAS2}: {D}etailed
+                  {G}eometrical {C}alibration},
+  institution =  {ARI},
+  year =         2003,
+  month =        {November},
+  note =         {GAIA-ARI-HL-001}
+}
+
+@TechReport{gdaas:gnucodingstd,
+  author =       {R.~Stallman},
+  title =        {{GNU} {C}oding {Standards}},
+  institution =  {GNU},
+  year =         2001,
+  month =        {March}
+}
+
+% Obsolete use gaia_livelink_valied and \citell{LL:ESA-SCI(2000)4)
+
+@TechReport{gdaas:javacodingstd,
+  author =       {P.~P.~L\'opez and X.~Luri and I.~Serraller},
+  title =        {{J}ava {C}ode {C}onventions},
+  institution =  {GMV/UB},
+  year =         2003,
+  month =        {March},
+  note =         {GMV-GDAAS2-SCG-004}
+}
+
+@TechReport{gdaas:prototypepaper,
+  author =       {W.~O'Mullane and L.~Lindegren},
+  title =        {{A}n {O}bject-{O}riented {F}ramework for {GAIA}
+                  {D}ata {P}rocessing},
+  institution =  {ESA},
+  year =         1999
+}
+
+@ARTICLE{gor05,
+  author =       {{G{\'o}rski}, K.~M. and {Hivon}, E. and {Banday},
+                  A.~J. and {Wandelt}, B.~D. and {Hansen}, F.~K. and
+                  {Reinecke}, M. and {Bartelmann}, M.},
+  title =        {HEALPix: A Framework for High-Resolution
+                  Discretization and Fast A nalysis of Data
+                  Distributed on the Sphere},
+  journal =      {\apj},
+  eprint =       {astro-ph/0409513},
+  year =         2005,
+  month =        apr,
+  volume =       622,
+  pages =        {759-771},
+  doi =          {10.1086/427976},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005ApJ...
+                  622..759G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@TechReport{greenplum:adminguide41,
+  author =       {EMC},
+  title =        { Greenplum Database 4.1 Administrator Guide },
+  institution =  { EMC Corporation },
+  year =         2011,
+  url =          {http://www.greenplum.com/community/downloads/documentation/},
+}
+
+%----------------------------------------------------------------------------
+%  CU6
+%----------------------------------------------------------------------------
+
+@TechReport{greenplum:installguide41,
+  author =       {EMC},
+  title =        { Greenplum Database 4.1 Installation Guide },
+  institution =  { EMC Corporation },
+  year =         2011,
+  url =          {http://www.greenplum.com/community/downloads/documentation/},
+}
+
+@InProceedings{hamilton1843,
+  author =       {W.~R.~Hamilton },
+  title =        {On a new Species of Imaginary Quantities connected
+                  with a theory of Quaternions},
+  year =         1843,
+  booktitle =    {Proceedings of the Royal Irish Academy },
+  volume =       2,
+  pages =        {424-434},
+  url =          {http://www.maths.tcd.ie/pub/HistMath/People/Hamilton/Quatern1/Quatern1.html},
+}
+
+@InProceedings{hamilton1844,
+  author =       {W.~R.~Hamilton },
+  title =        {On Quaternions},
+  year =         1847,
+  booktitle =    {Proceedings of the Royal Irish Academy },
+  volume =       3,
+  pages =        {1-16},
+  url =          {http://www.maths.tcd.ie/pub/HistMath/People/Hamilton/Quatern2/Quatern2.html},
+}
+
+@InProceedings{hamilton:onquat,
+  author =       {William Rowan Hamilton },
+  title =        {ON QUATERNIONS, OR ON A NEW SYSTEM OF IMAGINARIES IN
+                  ALGEBRA },
+  year =         1844,
+  booktitle =    {Proceedings of the Royal Irish Academy },
+  volume =       3,
+  pages =        {1-16},
+  url =          {http://www.maths.tcd.ie/pub/HistMath/People/Hamilton/OnQuat/OnQuat.pdf},
+}
+
+@TechReport{herschel:codingstandards,
+  author =       {J.~Brumfit},
+  title =        {{J}ava {C}oding {S}tandard and {G}uidelines for the
+                  {H}erschel {C}ommon {S}cience {S}ystem},
+  institution =  {ESTEC},
+  year =         2002,
+  month =        {October},
+  note =         {HSCDT/TN009}
+}
+
+@InProceedings{hipparcos:history,
+  author =       {E.~H{\o}g and P.~L.~Bernacca and L.~Emiliani},
+  title =        {Early Phases of the Hipparcos Project},
+  year =         1997,
+  booktitle =    {Proc.\ of Hipparcos Venice 97},
+  editor =       {M.A.C.~Perryman and P.L.~Bernacca},
+  pages =        {xxvii--xxxv}
+}
+
+@TechReport{hipparcos:threestep,
+  author =       {L.~Lindegren},
+  title =        {A three-step procedure for deriving positions,
+                  proper motions, and parallaxes of stars observed by
+                  scanning great circles },
+  institution =  {Lund Observatory},
+  year =         1976,
+  month =        {October},
+  note =         {Lund Observatory Technical note}
+}
+
+
+
+%----------------------------------------------------------------------------
+%  WWW
+%----------------------------------------------------------------------------
+
+@TechReport{intersystems:chartingthegalaxy,
+  author =       { O'Mullane W., Nagjee V. },
+  title =        { Charting the Galaxy with the Gaia Satellite and
+                  InterSystems Cach\'{e} },
+  institution =  { InterSystems and DPAC },
+  year =         2010,
+  url =          {http://www.intersystems.com/cache/whitepapers/charting_the_galaxy.html},
+}
+
+@ARTICLE{it:agile,
+  author =       {C. Larman and V. R. Basili},
+  journal =      {Computer},
+  title =        "{Iterative and Incremental Developments: A Brief History}",
+  year =         2003,
+  volume =       {36},
+  number =       {6},
+  pages =        {47-56},
+  keywords =     {history;software engineering;agile methods;iterative and incremental
+                 developments;iterative enhancement;software engineering;software system;
+                 Application software;Feedback;Government;History;Iterative methods;Personnel;
+                 Programming;Radio access networks;Terminology;Testing},
+  doi =          {10.1109/MC.2003.1204375},
+  month =        jun,
+}
+
+%-----
+% CU7 referenced entries start
+%-----
+
+@TechReport{it:javapopular,
+  author =       {TIOBE Software },
+  title =        {TIOBE Programming Community Index },
+  year =         2005,
+  institution =  {TIOBE},
+  url =          {http://www.tiobe.com/tiobe-index},
+}
+
+@ARTICLE{moore65,
+  author =       {{M}oore, Gordon E.},
+  title =        {Cramming more components onto integrated circuits},
+  journal =      {Electronics},
+  year =         1965,
+  pages =        114,
+  month =        apr,
+  volume =       38
+}
+
+@ARTICLE{mpclass:Tholen,
+  author =       {D.~J.~Tholen},
+  title =        {Asteroid taxonomy from cluster analysis of
+                  photometry},
+  journal =      {Ph.D.~Thesis},
+  year =         1984
+}
+
+@Article{mpclass:bus2002a,
+  author =       {S.~J.~Bus and R.~P.~Binzel},
+  title =        {Phase II of the Small Main-Belt Asteroid
+                  Spectroscopic Survey: The Observations},
+  journal =      {Icarus},
+  volume =       158,
+  pages =        {106--145},
+  year =         2002
+}
+
+@Article{mpclass:warell,
+  author =       {J.~Warell and C.-I.~Lagerkvist},
+  title =        {Asteroid taxonomy in the Gaia photometric system},
+  journal =      {\aap},
+  volume =       {submitted},
+  year =         2006
+}
+
+@InProceedings{munari2000,
+  author =       {U.~Munari },
+  title =        { The diffuse interstellar band at 8620 Å: A good
+                  reddening tracer for GAIA},
+  year =         2000,
+  booktitle =    {Molecules in Space and in the Laboratory,
+                  Proceedings of a workshop held 2-5 June 1999 in
+                  Carloforte, Cagliari.},
+  volume =       67,
+  pages =        {179--},
+  publisher =    {I. Porceddu, and S. Aiello. Bologna, Italy: Italian
+                  Physical Society, Conference Proceedings}
+}
+%----------------------------------------------------------------------------
+%  Oracle
+%----------------------------------------------------------------------------
+
+@TechReport{ndac:nullspace,
+  author =       { L.~Lindegren },
+  title =        { {P}seudosolution and pseudocovariances of
+                  least-squares problems with known null space },
+  institution =  { Lund Observatory },
+  year =         { 1983 },
+  month =        { April },
+  note =         { NDAC/LO/018, Hipparcos NDAC }
+}
+
+@TechReport{omg:tmtcxml,
+  author =       {Unknown},
+  title =        {Telemetric and Command Data Specification},
+  institution =  {Object Management Group --- Space Domain Task Force},
+  year =         2003,
+  month =        {March},
+  note =         {space/2003-03-04},
+  url =          {http://www.omg.org/docs/space/03-03-12.pdf},
+}
+
+@INPROCEEDINGS{omu01,
+  author =       {{O'Mullane}, W. and {Banday}, A.~J. and
+                  {G{\'o}rski}, K.~M. and {Kunszt}, P. and {Szalay},
+                  A.~S.},
+  title =        {{S}plitting the {S}ky - {HTM} and {HEALP}ix},
+  booktitle =    {Mining the Sky},
+  year =         2001,
+  editor =       {{Banday}, A.~J. and {Zaroubi}, S. and {Bartelmann},
+                  M.},
+  pages =        {638-+},
+  doi =          {10.1007/10849171_84},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001misk.c
+                  onf..638O&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@TechReport{oracle:RAC,
+  author =       {Oracle Corporation },
+  title =        {Installing Oracle RAC 10g on Linux x86},
+  year =         2006,
+  institution =  {Oracle},
+  month =        {September},
+  utl =          {http://www.oracle.com/technology/pub/articles/smiley_rac10g_install.html}
+}
+
+@TechReport{oracle:dell,
+  author =       {Dell support },
+  title =        {Linux Deployment guide },
+  year =         2006,
+  institution =  {Dell},
+  month =        {September},
+  note =
+                  {http://support.dell.com/support/edocs/software/appora10/lin10g/en/dg/10g21en0.pdf}
+}
+
+@article{paper:skyservermining,
+  author =       {J.~Gray and A.~S.~Szalay and A.~Thakar and P.~Kunszt
+                  and C.~Stoughton and D.~Slutz and J.~Vandenberg},
+  title =        {Data {M}ining in the {SDSS} {S}ky{S}erver
+                  {D}atabase},
+  year =         2003,
+  journal =      {Distributed Data and Structures 4: Records of the
+                  4th International Meeting, W. Litwin, G.Levy (eds),
+                  Paris France March 2002},
+}
+
+@article{paper:vodm,
+  author =       {J.~McDowell },
+  title =        {Data models for the VO},
+  year =         2004,
+  journal =      {Toward an International Virtual Observatory:
+                  Proceedings of the ESO/ESA/NASA/NSF Conference Held
+                  at Garching, Germany, 10-14 June 2002, ESO
+                  ASTROPHYSICS SYMPOSIA. ISBN 3-540-21001-6},
+}
+
+@phdthesis{phd:swb,
+  author =       {Brown, S.W.},
+  title =        {Characterisation and {M}itigation of {R}adiation
+                  {D}amage on the {G}aia {A}strometric {F}ield},
+  year =         2010,
+  school =       {Institute of {A}stronomy, {U}niversity of
+                  {C}ambridge},
+  address =      {Madingley Road, Cambridge, CB3 0HA, United Kingdom}
+}
+
+@TechReport{planck:dbtestreport,
+  author =       {C.~Vuerli and W.~O'Mullane},
+  title =        {{DBMS-COTS} test week report},
+  institution =  {ESA},
+  year =         2000,
+  month =        {February},
+  note =         {PL-COM-OAT-TN-009}
+}
+
+%----------------------------------------------------------------------------
+%  IVOA Standards
+%----------------------------------------------------------------------------
+
+@TechReport{roemer:proposal,
+  author =       {E.~H{\o}g},
+  title =        {A new era of global astrometry and photometry from
+                  space and ground},
+  institution =  {CUO},
+  year =         1994,
+  month =        {February},
+  note =         {Contribution at the G. Colombo Memorial Conference :
+                  Ideas for Space Research after the Year 2000.}
+}
+
+@TechReport{roemer:submit,
+  author =       {U.~Bastian and G.~Gilmore and J.L.~Halbwachs and
+                  E.~H{\o}g and J.~Knude and J.~Kovalevsky and
+                  A.~Labeyrie and F.~van~Leeuwen and L.~Lindegren and
+                  J.~W.~Pel and H.~Schrijver and R.~Stabell and
+                  P.~Thejll},
+  title =        {ROEMER},
+  institution =  {Lund Observatory},
+  year =         1993,
+  month =        {July},
+  note =         {Proposal for a Third Medium Size ESA Mission (M3),
+                  Lund 1993}
+}
+
+@INPROCEEDINGS{royce70,
+  author =       {{R}oyce, Winston},
+  title =        {{M}anaging the {D}evelopment of {L}arge {S}oftware
+                  {S}ystems},
+  booktitle =    {Proceedings of IEEE WESCON },
+  year =         1970,
+  month =        {August},
+  pages =        {1-9},
+  url =          {http://www.cs.umd.edu/class/spring2003/cmsc838p/Process/waterfall.pdf},
+}
+
+@TechReport{sequel,
+  author =       { Chamberlin D., Boyce R. },
+  title =        { SEQUL: A Structured English Query Language },
+  institution =  { IBM research laboratory},
+  year =         1974,
+  url =          {http://faculty.cse.tamu.edu/yurttas/PL/DBL/docs/sequel-1974.pdf},
+}
+
+@article{shuster93,
+  author =       {Malcolm D. Shuster},
+  title =        {A survey of attitude representations},
+  journal =      {{J}ournal of the astronautical sciences },
+  volume =       {41, n.4},
+  year =         1993,
+  pages =        {439-517}
+}
+
+@TechReport{sun:codingstandards,
+  author =       {Sun Microsystems},
+  title =        {Code Conventions for the Java Programming Language },
+  institution =  {Sun},
+  publisher =    {Addison Wesley},
+  year =         1999,
+  month =        {December},
+  note =         {http://java.sun.com/docs/codeconv}
+}
+
+@TechReport{sun:doccomments,
+  author =       {Sun Microsystems},
+  title =        {How to write Doc Comments for JavaDoc},
+  institution =  {Sun},
+  year =         2000,
+  note =
+                  {http://java.sun.com/products/jdk/javadoc/writingdoccomments/index.html}
+}
+
+@TechReport{sun:style,
+  author =       {Sun Microsystems},
+  title =        {Java Look and Feel Design Guidelines},
+  institution =  {Sun},
+  year =         1999,
+  month =        {October},
+  note =         {http://java.sun.com/products/jlf/dg/index.htm}
+}
+
+@ARTICLE{tapiador2014,
+  author =       {Tapiador, D. and O'Mullane, W. and Browni,
+                  A. G. A. and Luri Carrascoso, X. and Huedo, E. and
+                  Osuna, P.},
+  title =        {A Framework for Building Hypercubes Using MapReduce},
+  year =         2014,
+  journal =      {Computer Physics Communications},
+  volume =       185,
+  number =       5,
+  doi =          {10.1016/j.cpc.2014.02.010}
+}
+
+@InProceedings{terLinden05,
+  author =       {M.~ter~Linden and H.~de~Wolf and R.~Grim },
+  title =        { GridAssist, a User Friendly Grid-based Workflow
+                  Management Tool},
+  year =         2005,
+  booktitle =    {2005 International Conference on Parallel Processing
+                  Workshops (ICPPW'05)},
+  volume =       {icppw},
+  pages =        {5-10},
+  publisher =    {IEEE Computer Society},
+  doi =          {10.1109/ICPPW.2005.37},
+}
+
+@misc{www:linpack,
+  key =          {LINPACK},
+  note =         { Linpack standard numerical benchmark},
+  url =          {http://www.top500.org/lists/linpack.php},
+}
+
+@LiveLink{LL:SATSCMP,
+   author = {I.~Leon},
+   title={SCIENCE ARCHIVE - SOFTWARE CONFIGURATION MANAGEMENT PLAN (SCMP)},
+   institution={European Space Astronomy Centre, Villafranca, Madrid},
+   year={2009},
+   month = nov,
+   url={http://www.rssd.esa.int/llink/livelink/fetch/-415780/495310/1051419/Sw_Conf_Mng_Plan_v2-0.pdf?nodeid=2942288&vernum=-2},
+   note={},
+   livelinknumber={SAT\_GEN\_PL\_2.0\_01\_SCMP\_05112009},
+   livelinkshortnumber={{SATSCMP}}
+}
+
+@LiveLink{LL:SATMP,
+   author = {P.~Osuna},
+   title={Science Archives and VO Team (SAT) Management Plan},
+   institution={European Space Astronomy Centre, Villafranca, Madrid},
+   year={2011},
+   month=may,
+   url={http://www.rssd.esa.int/llink/livelink/fetch/-415780/2741092/SAT_GEN_PL_3.0_06_MP_30May2011.pdf?nodeid=3120171&vernum=-2},
+   note={},
+   livelinknumber={SAT\_GEN\_PL\_3.0\_06\_MP\_30\_May\_2011},
+   livelinkshortnumber={{SATMP}}
+}
+
+@LiveLink{LL:ESA/SPC(2009)6,
+	author = {ESA},
+	title={Licensing of Data Processing Software for the Science Programme},
+	institution={},
+	year={2009},
+	month=jan,
+	url={},
+	livelinknumber={ESA/SPC(2009)6},
+	livelinkshortnumber={{ESA/SPC(2009)6}}
+}
+
+@LiveLink{IVOAMOC,
+	author = {Thomas Boch and Tom Donaldson and Daniel Durand and Pierre Fernique and Wil O'Mullane and Martin Reinecke and Mark Taylor
+       	},
+	title={MOC - HEALPix Multi-Order Coverage map Version 1.0},
+	institution={},
+	year={2014},
+	month=jun,
+	url={http://www.ivoa.net/documents/MOC/},
+	livelinknumber={},
+	livelinkshortnumber={{IVOAMOC}}
+}
+
+@misc{www:top500,
+  key =          {TOP500},
+  note =         {{TOP500} {S}upercomputer {S}ites},
+  url =          {http://www.top500.org},
+}
+
+@inproceedings{Wang:2011:QDS:2063348.2063364,
+  author =       {Wang, Daniel L. and Monkewitz, Serge M. and Lim,
+                  Kian-Tat and Becla, Jacek},
+  title =        {Qserv: A Distributed Shared-nothing Database for the
+                  LSST Catalog},
+  booktitle =    {State of the Practice Reports},
+  series =       {SC '11},
+  year =         2011,
+  isbn =         {978-1-4503-1139-7},
+  location =     {Seattle, Washington},
+  pages =        {12:1--12:11},
+  articleno =    12,
+  numpages =     11,
+  doi =          {10.1145/2063348.2063364},
+  acmid =        2063364,
+  publisher =    {ACM},
+  address =      {New York, NY, USA},
+  keywords =     {MPP, database, distributed, file system, parallel,
+                  shared-nothing},
+}
+
+@article{zucker:1994,
+author = {{Zucker}, S. and {Mazeh}, T.},
+ title = "{Study of spectroscopic binaries with TODCOR. 1: A new two-dimensional correlation algorithm to derive the radial velocities of the two components}",
+journal = {\apj},
+keywords = {Algorithms, Binary Stars, Cross Correlation, Radial Velocity, Two Dimensional Models, Doppler Effect, Fast Fourier Transformations},
+  year = 1994,
+ month = jan,
+volume = 420,
+ pages = {806-810},
+   doi = {10.1086/173605},
+adsurl = {http://adsabs.harvard.edu/abs/1994ApJ...420..806Z},
+adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@article{zucker:2004,
+author = {{Zucker}, S. and {Mazeh}, T. and {Santos}, N.~C. and {Udry}, S. and
+{Mayor}, M.},
+ title = "{Multi-order TODCOR: Application to observations taken with the CORALIE echelle spectrograph. II. A planet in the system <ASTROBJ>HD 41004</ASTROBJ>}",
+journal = {\aap},
+keywords = {methods: data analysis, techniques: radial velocities, stars: binaries: spectroscopic, stars: individual: HD 41004, stars: low-mass, brown dwarfs},
+  year = 2004,
+ month = nov,
+volume = 426,
+ pages = {695-698},
+   doi = {10.1051/0004-6361:20040384},
+adsurl = {http://adsabs.harvard.edu/abs/2004A\%26A...426..695Z},
+adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@misc{Kaiser04,
+  author = {Kaiser, N.},
+  title = {Addition of Images with Varying Seeing},
+  year = {2004},
+  url = {http://spider.ipac.caltech.edu/staff/fmasci/home/astro_refs/PanStars_Coadder.pdf},
+  note = {Pan-STARRS Document Control, PSDC-002-011-xx}
+}
+
+@misc{c1962method,
+  title = {Method and means for recognizing complex patterns},
+  author = {Paul V. C. Hough},
+  url = {https://www.google.com/patents/US3069654},
+  year = {1962},
+  publisher = {Google Patents},
+  note = {US Patent 3,069,654}
+}
+
+@misc{GaiaSpecs,
+  author = {{The Gaia Team}},
+  title = "{Science Performance of the Gaia Mission}",
+  url = {https://www.cosmos.esa.int/web/gaia/science-performance},
+}
+
+@Misc{Rucio,
+  key = {Rucio},
+  title = "{Rucio Distributed Data Management Documentation}",
+  url =   {http://rucio.cern.ch/}
+}
+
+@Misc{GlobusTransfer,
+  author = {Globus},
+  title = "{Globus Transfer API Documentation}",
+  url =   {https://docs.globus.org/api/transfer/}
+}
+
+@Misc{GPFS,
+  key = {GPFS},
+  title = "{IBM Spectrum Scale}",
+  url =   {https://www.ibm.com/us-en/marketplace/scale-out-file-and-object-storage}
+}
+
+@Misc{HPSS,
+  key = {HPSS},
+  title = "{HPSS -- High Performance Storage Systems}",
+  url =   {http://hpss-collaboration.org/}
+}
+
+@Misc{AmazonGlacier,
+  author = {Amazon},
+  title = "{Amazon Glacier -- Cloud Archive}",
+  url =   {https://aws.amazon.com/glacier/}
+}
+
+@Misc{CampaignStorage,
+  key = {Campaign Storage},
+  title = "{Campaign Storage}",
+  url =   {http://campaignstorage.com/}
+}
+
+@Misc{Quobyte,
+  key = {Quobyte},
+  title = "{Quobyte -- Data Center File System}",
+  url =   {https://www.quobyte.com/}
+}
+
+@Misc{MariaDB,
+  key = {MariaDB},
+  title = "{MariaDB -- Enterprise Open Source Database \& Data Warehouse}",
+  url =   {https://mariadb.com/}
+}
+
+@Misc{Oracle,
+  author = {Oracle},
+  title = "{Oracle -- Database 12c}",
+  url =   {https://www.oracle.com/database/index.html}
+}
+
+@Misc{SQLServer,
+  author = {Microsoft},
+  title = "{Microsoft -- SQL Server 2016}",
+  url =   {https://www.microsoft.com/en-us/sql-server/sql-server-2016}
+}
+
+@Misc{YAML,
+  key = {YAML},
+  title = "{The Official YAML Web Site}",
+  url =   {http://yaml.org/}
+}
+
+@Misc{log4cxx,
+  author = {Apache Logging Services Project},
+  title = "{Apache log4cxx}",
+  url =   {https://logging.apache.org/log4cxx/latest_stable/}
+}
+
+@Misc{RabbitMQ,
+  key = {RabbitMQ},
+  title = "{RabbitMQ -- Messaging that just works}",
+  url =   {https://www.rabbitmq.com/}
+}
+
+@Misc{MPI,
+  key = {MPI},
+  title = "{MPI Documents}",
+  url =   {http://mpi-forum.org/docs/}
+}
+
+@Misc{mpi4py,
+  key = {MPI4PY},
+  title = "{MPI for Python}",
+  url =   {http://mpi4py.readthedocs.io/en/stable/}
+}
+
+@Misc{OpenMP,
+  key = {OpenMP},
+  title = "{OpenMP}",
+  url =   {http://www.openmp.org/}
+}
+
+@Misc{Pegasus,
+  key = {Pegasus},
+  title = "{Pegasus WMS}",
+  url =   {https://pegasus.isi.edu/}
+}
+
+@Misc{HTCondor,
+  key = {HTCondor},
+  title = "{HTCondor}",
+  url =   {https://research.cs.wisc.edu/htcondor/index.html}
+}
+
+@article{Dean:2008:MSD:1327452.1327492,
+  author = {Dean, Jeffrey and Ghemawat, Sanjay},
+  title = {MapReduce: Simplified Data Processing on Large Clusters},
+  journal = {Commun. ACM},
+  issue_date = {January 2008},
+  volume = {51},
+  number = {1},
+  month = jan,
+  year = {2008},
+  issn = {0001-0782},
+  pages = {107--113},
+  numpages = {7},
+  doi = {10.1145/1327452.1327492},
+  acmid = {1327492},
+  publisher = {ACM},
+  address = {New York, NY, USA},
+}
+
+@article{Chang:2008:BDS:1365815.1365816,
+  author = {Chang, Fay and Dean, Jeffrey and Ghemawat, Sanjay and Hsieh, Wilson C. and
+            Wallach, Deborah A. and Burrows, Mike and Chandra, Tushar and
+            Fikes, Andrew and Gruber, Robert E.},
+  title = {Bigtable: A Distributed Storage System for Structured Data},
+  journal = {ACM Trans. Comput. Syst.},
+  issue_date = {June 2008},
+  volume = {26},
+  number = {2},
+  month = jun,
+  year = {2008},
+  issn = {0734-2071},
+  pages = {4:1--4:26},
+  articleno = {4},
+  numpages = {26},
+  doi = {10.1145/1365815.1365816},
+  acmid = {1365816},
+  publisher = {ACM},
+  address = {New York, NY, USA},
+  keywords = {Large-Scale Distributed Storage},
+}
+
+@inproceedings{Burrows:2006:CLS:1298455.1298487,
+  author = {Burrows, Mike},
+  title = {The Chubby Lock Service for Loosely-coupled Distributed Systems},
+  booktitle = {Proceedings of the 7th Symposium on Operating Systems Design and Implementation},
+  series = {OSDI '06},
+  year = {2006},
+  isbn = {1-931971-47-1},
+  location = {Seattle, Washington},
+  pages = {335--350},
+  numpages = {16},
+  url = {http://dl.acm.org/citation.cfm?id=1298455.1298487},
+  acmid = {1298487},
+  publisher = {USENIX Association},
+  address = {Berkeley, CA, USA},
+}
+
+@article{Pike:2005:SP:962135,
+  author = {Rob Pike and Sean Dorward and Robert Griesemer and Sean Quinlan},
+  title = {Interpreting the Data: Parallel Analysis with Sawzall},
+  journal = {Scientific Programming},
+  pages = 277,
+  volume = 13,
+  year = 2005,
+  doi = {10.1155/2005/962135},
+}
+
+@article{Melnik:2010:DIA:1920841.1920886,
+  author = {Melnik, Sergey and Gubarev, Andrey and Long, Jing Jing and
+            Romer, Geoffrey and Shivakumar, Shiva and Tolton, Matt and Vassilakis, Theo},
+  title = {Dremel: Interactive Analysis of Web-scale Datasets},
+  journal = {Proc. VLDB Endow.},
+  issue_date = {September 2010},
+  volume = {3},
+  number = {1-2},
+  month = sep,
+  year = {2010},
+  issn = {2150-8097},
+  pages = {330--339},
+  numpages = {10},
+  doi = {10.14778/1920841.1920886},
+  acmid = {1920886},
+  publisher = {VLDB Endowment},
+}
+
+@Inproceedings{Waas:2009:97836420342207,
+  author = "Waas, Florian M.",
+  editor = "Castellanos, Malu and Dayal, Umesh and Sellis, Timos",
+  title = "Beyond Conventional Data Warehousing --- Massively Parallel Data Processing with Greenplum Database",
+  bookTitle = "Business Intelligence for the Real-Time Enterprise: Second International Workshop, BIRTE 2008, Auckland, New Zealand, August 24, 2008, Revised Selected Papers",
+  year = "2009",
+  publisher = "Springer Berlin Heidelberg",
+  address = "Berlin, Heidelberg",
+  pages = "89--96",
+  abstract = "In this presentation we discuss trends and challenges for data warehousing beyond conventional application areas. In particular, we discuss how a massively parallel system like Greenplum Database can be used for MapReduce-like data processing.",
+  isbn = "978-3-642-03422-0",
+  doi = "10.1007/978-3-642-03422-0_7",
+  url = {http://www.greenplum.com/resources/},
+}
+
+@inproceedings{Isard:2007:DDD:1272996.1273005,
+  author = {Isard, Michael and Budiu, Mihai and Yu, Yuan and Birrell, Andrew and
+            Fetterly, Dennis},
+  title = {Dryad: Distributed Data-parallel Programs from Sequential Building Blocks},
+  booktitle = {Proceedings of the 2Nd ACM SIGOPS/EuroSys European Conference on Computer Systems 2007},
+  series = {EuroSys '07},
+  year = {2007},
+  isbn = {978-1-59593-636-3},
+  location = {Lisbon, Portugal},
+  pages = {59--72},
+  numpages = {14},
+  doi = {10.1145/1272996.1273005},
+  acmid = {1273005},
+  publisher = {ACM},
+  address = {New York, NY, USA},
+  keywords = {cluster computing, concurrency, dataflow, distributed programming},
+}
+
+@inproceedings{Chattopadhyay:2011:37200,
+    author = {B. Chattopadhyay and Liang Lin and Weiran Liu and Sagar Mittal
+              P. Aragonda and V. Lychagina and Younghee Kwon and Michael Wong},
+    title = {Tenzing A SQL Implementation On The MapReduce Framework},
+    year = 2011,
+    booktitle = {Proceedings of VLDB},
+    volume = 4,
+    pages = {1318--1327},
+    url = {https://research.google.com/pubs/pub37200.html},
+}
+
+@techreport{Szalay:2008:Graywulf,
+  author = {Szalay, Alex S. and Bell, Gordon and Vandenberg, Jad and
+            Wonders, Alainna and Burns, Randal and Fay, Dan and Heasley, Jim
+            and Hey, Tony and Nieto-SantiSteban, Maria and Thakar, Ani
+            and Ingen, Catharine van and Wilton, Richard},
+  title = {GrayWulf: Scalable Clustered Architecture for Data Intensive Computing},
+  year = {2008},
+  month = sep,
+  number = {MSR-TR-2008-187},
+  institution = {Microsoft},
+  url = {https://www.microsoft.com/en-us/research/publication/graywulf-scalable-clustered-architecture-for-data-intensive-computing/},
+}
+
+@techreport{Gray:2006:Zones,
+  author = {Gray, Jim},
+  title = {The Zones Algorithm for Finding Points-Near-a-Point or Cross-Matching Spatial Datasets},
+  number = {MSR-TR-2006-52},
+  year = {2006},
+  month = apr,
+  abstract = {Zones index an N-dimensional Euclidian or metric space to efficiently support points-near-a-point queries either within a dataset or between two datasets. The approach uses relational algebra and the B-Tree mechanism found in almost all relational database systems. Hence, the Zones Algorithm gives a portable-relational implementation of points-near-point, spatial cross-match, and self-match queries. This article corrects some mistakes in an earlier article we wrote on the Zones Algorithm and describes some algorithmic improvements. The Appendix includes an implementation of point-near-point, self-match, and cross-match using the USGS city and stream gauge database.
+},
+  institution = {Microsoft},
+  url = {https://www.microsoft.com/en-us/research/publication/the-zones-algorithm-for-finding-points-near-a-point-or-cross-matching-spatial-datasets/},
+}
+
+@INPROCEEDINGS{Simmhan:2009:4755781,
+  author={Y. Simmhan and R. Barga and C. van Ingen and M. Nieto-Santisteban and L. Dobos and
+          N. Li and M. Shipway and A. S. Szalay and S. Werner and J. Heasley},
+  booktitle = {2009 42nd Hawaii International Conference on System Sciences},
+  title = {GrayWulf: Scalable Software Architecture for Data Intensive Computing},
+  year = {2009},
+  pages = {1-10},
+  keywords = {software architecture;Beowulf clusters;GrayWulf;Pan-STARRS system;cluster infrastructure software;parallel application design;petabyte data sets;Software architecture},
+  doi = {10.1109/HICSS.2009.235},
+  ISSN = {1530-1605},
+  month = jan,
+}
+
+@misc{Kirsch:2012,
+  author = {Nathan Kirsch},
+  title = "{WD Red 3TB NAS Hard Drive Review}",
+  url = {http://www.legitreviews.com/article/2092/3/},
+  year = 2012,
+  month = dec,
+}
+
+@inproceedings{Nobari:2013:TIS:2463676.2463700,
+  author = {Nobari, Sadegh and Tauheed, Farhan and Heinis, Thomas and Karras, Panagiotis and
+            Bressan, St{\'e}phane and Ailamaki, Anastasia},
+  title = {TOUCH: In-memory Spatial Join by Hierarchical Data-oriented Partitioning},
+  booktitle = {Proceedings of the 2013 ACM SIGMOD International Conference on Management of Data},
+  series = {SIGMOD '13},
+  year = {2013},
+  isbn = {978-1-4503-2037-5},
+  location = {New York, New York, USA},
+  pages = {701--712},
+  numpages = {12},
+  doi = {10.1145/2463676.2463700},
+  acmid = {2463700},
+  publisher = {ACM},
+  address = {New York, NY, USA},
+  keywords = {indexing, scalable algorithms, spatial joins, touch},
+}
+
+@misc{Monash:2009:teradata,
+  author = {Curt Monash},
+  title = "{Teradata and Netezza are doing MapReduce too}",
+  year = 2009,
+  month = sep,
+  url = {http://www.dbms2.com/2009/09/03/teradata-and-netezza-are-doing-mapreduce-too/},
+}
+
+@misc{Monash:2009:ebay,
+  author = {Curt Monash},
+  title = "{eBay's two enormous data warehouses}",
+  year = 2009,
+  month = apr,
+  url = {http://www.dbms2.com/2009/04/30/ebays-two-enormous-data-warehouses/},
+}
+
+@misc{Monash:2010:ebay,
+  author = {Curt Monash},
+  title = "{eBay followup — Greenplum out, Teradata > 10 petabytes, Hadoop has some value, and more}",
+  year = 2010,
+  month = oct,
+  url = {http://www.dbms2.com/2010/10/06/ebay-followup-greenplum-out-teradata-10-petabytes-hadoop-has-some-value-and-more/},
+}
+
+@misc{Foley:2011:Zdnet,
+  author = {Foley, Mary Jo},
+  title = "{Microsoft drops Dryad; puts its big-data bets on Hadoop}",
+  year = 2011,
+  month = nov,
+  url = {http://www.zdnet.com/article/microsoft-drops-dryad-puts-its-big-data-bets-on-hadoop/},
+}
+
+@misc{Zicaro:2011:ODBMS,
+  author = {Roberto V. Zicari},
+  title = "{Objects in Space}",
+  year = 2011,
+  month = feb,
+  url = {http://www.odbms.org/blog/2011/02/objects-in-space/},
+}
+
+@misc{Schuman:2004:eWeek,
+  author = {Evan Schuman},
+  title = "{At Wal-Mart, Worlds Largest Retail Data Warehouse Gets Even Larger}",
+  year = 2004,
+  month = oct,
+  url = {http://www.eweek.com/enterprise-apps/at-wal-mart-worlds-largest-retail-data-warehouse-gets-even-larger},
+}
+
+@misc{Tommaney:2009:MySQLConf,
+  author = {Jim Tommaney},
+  title = {Calpont: Open Source Columnar Storage Engine for Scalable MySQL},
+  year = 2009,
+  month = apr,
+  url = {https://web.archive.org/web/20090429121116/http://www.mysqlconf.com/mysql2009/public/schedule/detail/8997},
+}
+
+@misc{TokuDB:2013:White,
+  title = "{TokuDB: Scalable High Performance for MySQL and MariaDB Databases}",
+  author = {TokuTek},
+  year = 2013,
+  month = apr,
+  url = {https://web.archive.org/web/20130819012209/http://www.tokutek.com/wp-content/uploads/2013/04/Tokutek-White-Paper.pdf},
+}
+
+@misc{Hoff:2008:Skype,
+  author = {Todd Hoff},
+  title = "{Skype Plans For PostgreSQL To Scale To 1 Billion Users}",
+  year = 2008,
+  month = apr,
+  url = {http://highscalability.com/skype-plans-postgresql-scale-1-billion-users},
+}
+
+@misc{DeWitt:2008:MapReduce,
+  title = "{MapReduce: A major step backwards}",
+  author = {David DeWitt},
+  month = jan,
+  year = 2008,
+  url = {https://web.archive.org/web/20090327050223/http://www.databasecolumn.com/2008/01/mapreduce-a-major-step-back.html},
+
+}
+
+@misc{DeWitt:2008:MapReduceII,
+  title = "{MapReduce II}",
+  author = {David DeWitt},
+  month = jan,
+  year = 2008,
+  url = {https://web.archive.org/web/20090326224219/http://www.databasecolumn.com:80/2008/01/mapreduce-continued.html},
+}
+
+@misc{Intersystems:2008:Globals,
+  author = {Intersystems},
+  title = "{Using Cache Globals}",
+  url = {http://docs.intersystems.com/documentation/cache/20082/pdfs/GGBL.pdf},
+  year = 2008,
+  month = oct,
+}
+
+@misc{Peschka:2010:HBase,
+  author = {Jeremiah Peschka},
+  title = {Facebook Messaging - HBase Comes of Age},
+  month = nov,
+  year = 2010,
+  url = {https://web.archive.org/web/20110215081418/http://nosqlpedia.com/wiki/Facebook_Messaging_-_HBase_Comes_of_Age},
+}
+
+@misc{Ulin:2013:Percona,
+  author = {Tomas Ulin},
+  url = {https://www.youtube.com/watch?v=OpHTV59I1gs},
+  title = "{Driving MySQL Innovation}",
+  year = 2013,
+  month = apr,
+  howpublished = {Percona Live: MySQL Conference and Expo},
+}
+
+@article{Dorigo:2005:XRootd,
+  author = {A. Dorigo and P. Elmer and F. Furano and A. Hanushevsky},
+  title = "{XROOTD - A Highly scalable architecture for data access}",
+  journal = "WSEAS Transactions on Computers",
+  volume = 4,
+  pages = 348,
+  year = 2005,
+  month = apr,
+  url = {http://xrootd.org/presentations/xpaper3_cut_journal.pdf},
+}
+
+@INPROCEEDINGS{VanderPlas:6382200,
+  author = {J. VanderPlas and A. J. Connolly and {\v Z}. {Ivezi{\'c}} and A. Gray},
+  booktitle = {2012 Conference on Intelligent Data Understanding},
+  title = {Introduction to astroML: Machine learning for astrophysics},
+  year = 2012,
+  pages = {47-54},
+  doi = {10.1109/CIDU.2012.6382200},
+  month = oct,
+}
+
+@INPROCEEDINGS{Coster:2014:ION,
+  author = {A. Coster and V. Pankratius and F. Lind and P. Erickson and J. Semeter},
+  title = "{The Mahali Space Weather Project: Advancing GNSS Ionospheric Science}",
+  year = 2014,
+  pages = {1213-1221},
+  month = sep,
+  booktitle = {Proceedings of the 27th International Technical Meeting of
+               The Satellite Division of the Institute of Navigation (ION GNSS+ 2014)},
+  url = {https://www.ion.org/publications/abstract.cfm?articleID=12273},
+}
+
+@ARTICLE{Pankratius:7515118,
+  author={V. Pankratius and J. Li and M. Gowanlock and D. M. Blair and C. Rude
+          and T. Herring and F. Lind and P. J. Erickson and C. Lonsdale},
+  journal = {IEEE Intelligent Systems},
+  title = {Computer-Aided Discovery: Toward Scientific Insight Generation with Machine Support},
+  year = 2016,
+  volume = {31},
+  number = {4},
+  pages = {3-10},
+  doi = {10.1109/MIS.2016.60},
+  ISSN = {1541-1672},
+  month = jul,
+}
+
+@Misc{Dyke:2009:Madison,
+  author = {Paul Dyke},
+  title = "{Microsoft SQL Server Project code-named 'Madison'}",
+  year = 2009,
+  howpublished = {PASS Summit Unite},
+  url = {http://wiki.esi.ac.uk/w/files/5/5c/Dyke-Details_of_Project_Madison-1.pdf},
+}
+
+@inproceedings{DBLP:conf/cidr/BeclaW05,
+  author    = {Jacek Becla and
+               Daniel L. Wang},
+  title     = {Lessons Learned from Managing a Petabyte},
+  booktitle = {{CIDR} 2005, Second Biennial Conference on Innovative Data Systems
+               Research, Asilomar, CA, USA, January 4-7, 2005, Online Proceedings},
+  pages     = {70--83},
+  year      = {2005},
+  url       = {http://cidrdb.org/cidr2005/papers/P06.pdf},
+  timestamp = {Thu, 29 Jun 2017 19:21:39 +0200},
+  biburl    = {http://dblp.dagstuhl.de/rec/bib/conf/cidr/BeclaW05},
+  bibsource = {dblp computer science bibliography, http://dblp.org}
+}
+
+@inproceedings{Stonebraker:2005:CCD:1083592.1083658,
+  author = {Stonebraker, Mike and Abadi, Daniel J. and Batkin, Adam and Chen, Xuedong and
+            Cherniack, Mitch and Ferreira, Miguel and Lau, Edmond and Lin, Amerson and
+            Madden, Sam and O'Neil, Elizabeth and O'Neil, Pat and Rasin, Alex and
+            Tran, Nga and Zdonik, Stan},
+  title = {C-store: A Column-oriented DBMS},
+  booktitle = {Proceedings of the 31st International Conference on Very Large Data Bases},
+  series = {VLDB '05},
+  year = {2005},
+  isbn = {1-59593-154-6},
+  location = {Trondheim, Norway},
+  pages = {553--564},
+  numpages = {12},
+  url = {http://dl.acm.org/citation.cfm?id=1083592.1083658},
+  acmid = {1083658},
+  publisher = {VLDB Endowment},
+}
+
+@INPROCEEDINGS{Ivanova:2007:4274958,
+  author = {M. Ivanova and N. Nes and R. Goncalves and M. Kersten},
+  booktitle = {19th International Conference on Scientific and Statistical Database
+               Management (SSDBM 2007)},
+  title = "{MonetDB/SQL Meets SkyServer: the Challenges of a Scientific Database}",
+  year= 2007,
+  pages= 13,
+  keywords = {SQL;database management systems;MonetDB/SQL;SkyServer;open source database system;reference platform;scientific database;sloan digital sky survey;zoom-in/zoom-out access patterns;Astronomy;Data mining;Database systems;Kernel;Logic;Object oriented databases;Pattern analysis;Performance analysis;Prototypes;Spatial databases},
+  doi = {10.1109/SSDBM.2007.19},
+  ISSN = {1551-6393},
+  month = jul,
+}
+
+@article{DBLP:journals/debu/IdreosGNMMK12,
+  author    = {Stratos Idreos and
+               Fabian Groffen and
+               Niels Nes and
+               Stefan Manegold and
+               K. Sjoerd Mullender and
+               Martin L. Kersten},
+  title     = {MonetDB: Two Decades of Research in Column-oriented Database Architectures},
+  journal   = {{IEEE} Data Eng. Bull.},
+  volume    = {35},
+  number    = {1},
+  pages     = {40--45},
+  year      = {2012},
+  url       = {http://sites.computer.org/debull/A12mar/monetdb.pdf},
+  timestamp = {Tue, 17 Apr 2012 13:08:58 +0200},
+  biburl    = {http://dblp.uni-trier.de/rec/bib/journals/debu/IdreosGNMMK12},
+  bibsource = {dblp computer science bibliography, http://dblp.org}
+}
+
+@inproceedings{Pavlo:2009:CAL:1559845.1559865,
+  author = {Pavlo, Andrew and Paulson, Erik and Rasin, Alexander and Abadi, Daniel J. and
+           DeWitt, David J. and Madden, Samuel and Stonebraker, Michael},
+  title = {A Comparison of Approaches to Large-scale Data Analysis},
+  booktitle = {Proceedings of the 2009 ACM SIGMOD International Conference on Management
+               of  Data},
+  series = {SIGMOD '09},
+  year = {2009},
+  isbn = {978-1-60558-551-2},
+  location = {Providence, Rhode Island, USA},
+  pages = {165--178},
+  numpages = {14},
+  url = {http://doi.acm.org/10.1145/1559845.1559865},
+  doi = {10.1145/1559845.1559865},
+  acmid = {1559865},
+  publisher = {ACM},
+  address = {New York, NY, USA},
+  keywords = {benchmarks, mapreduce, parallel database},
+}

--- a/{{cookiecutter.repo_name}}/lsstbib/refs_ads.bib
+++ b/{{cookiecutter.repo_name}}/lsstbib/refs_ads.bib
@@ -1,0 +1,4688 @@
+@ARTICLE{1727RSPT...35..637B,
+  author =       {{Bradley}, J.},
+  title =        "{a Letter from the Reverend Mr. James Bradley
+                  Savilian Professor of Astronomy at Oxford, and
+                  F.R.S. to Dr.Edmond Halley
+                  Astronom. Reg. {\amp}c. Giving an Account of a New
+                  Discovered Motion of the Fix'd Stars.}",
+  journal =      {Royal Society of London Philosophical Transactions
+                  Series I},
+  year =         1727,
+  volume =       35,
+  pages =        {637-661},
+  adsurl =       {http://adsabs.harvard.edu/abs/1727RSPT...35..637B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{1978moas.coll..197L,
+  author =       {{Lindegren}, L.},
+  title =        "{Photoelectric astrometry - A comparison of methods
+                  for precise image location}",
+  keywords =     {ASTROMETRY, ELECTROPHOTOMETERS, POSITION (LOCATION),
+                  ESTIMATES, PHOTOELECTRIC EFFECT, WEIGHTING
+                  FUNCTIONS},
+  booktitle =    {IAU Colloq. 48: Modern Astrometry},
+  year =         1978,
+  editor =       {{Prochazka}, F.~V. and {Tucker}, R.~H.},
+  pages =        {197-217},
+  adsurl =       {http://adsabs.harvard.edu/abs/1978moas.coll..197L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1982A&A...114..278B,
+  author =       {{Bretagnon}, P.},
+  title =        "{Theory for the motion of all the planets - The
+                  VSOP82 solution}",
+  journal =      {\aap},
+  year =         1982,
+  month =        oct,
+  volume =       114,
+  pages =        {278-288},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1982A\%26A...114..278B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1983A&A...120..197S,
+  author =       {{Simon}, J.~L.},
+  title =        "{Theory for the motion of the four giant planets -
+                  The TOP 82 solution}",
+  journal =      {\aap},
+  year =         1983,
+  month =        apr,
+  volume =       120,
+  pages =        {197-202},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1983A\%26A...120..197S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1985ApJ...298...80C,
+  author =       {{Casertano}, S. and {Hut}, P.},
+  title =        "{Core radius and density measurements in N-body
+                  experiments Connections with theoretical and
+                  observational definitions}",
+  journal =      {\apj},
+  keywords =     {Astronomical Models, Density Distribution, Galactic
+                  Clusters, Many Body Problem, Star Clusters,
+                  Gravitational Effects, Monte Carlo Method},
+  year =         1985,
+  month =        nov,
+  volume =       298,
+  pages =        {80-94},
+  doi =          {10.1086/163589},
+  adsurl =       {http://adsabs.harvard.edu/abs/1985ApJ...298...80C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1985Icar...61..355Z,
+  author =       {{Zellner}, B. and {Tholen}, D.~J. and {Tedesco},
+                  E.~F.},
+  title =        "{The eight-color asteroid survey - Results for 589
+                  minor planets}",
+  journal =      {Icarus},
+  year =         1985,
+  month =        mar,
+  volume =       61,
+  pages =        {355-416},
+  doi =          {10.1016/0019-1035(85)90133-2},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1985Icar...61..355Z&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1985Icar...62..244G,
+  author =       {{Gr\"{u}n}, E. and {Zook}, H.~A. and {Fechtig},
+                  H. and {Giese}, R.},
+  title =        "{Collisional Balance of the Meteoritic Complex}",
+  journal =      {Icarus},
+  year =         1985,
+  month =        may,
+  volume =       62,
+  pages =        {244-272},
+  doi =          {10.1016/0019-1035(85)90121-6},
+  adsurl =
+                  {http://adsabs.harvard.edu/abs/1985Icar...62..244G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1986ApJ...304...62O,
+  author =       {{Otto}, S. and {Politzer}, H.~D. and {Preskill},
+                  J. and {Wise}, M.~B.  },
+  title =        "{The significance of voids}",
+  journal =      {\apj},
+  keywords =     {Cosmology, Galactic Clusters, Galaxies, Spatial
+                  Distribution, Statistical Analysis, Void Ratio,
+                  Density Distribution, Probability Distribution
+                  Functions, Significance, Statistical Correlation,
+                  Statistical Distributions},
+  year =         1986,
+  month =        may,
+  volume =       304,
+  pages =        {62-74},
+  doi =          {10.1086/164144},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/1986ApJ...304...62O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1988A&A...202..309B,
+  author =       {{Bretagnon}, P. and {Francou}, G.},
+  title =        "{Planetary theories in rectangular and spherical
+                  variables - VSOP 87 solutions}",
+  journal =      {\aap},
+  year =         1988,
+  month =        aug,
+  volume =       202,
+  pages =        {309-315},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1988A\%26A...202..309B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1989ApJ...345..245C,
+  author =       {{Cardelli}, J.~A. and {Clayton}, G.~C. and {Mathis},
+                  J.~S.},
+  title =        "{The relationship between infrared, optical, and
+                  ultraviolet extinction}",
+  journal =      {\apj},
+  keywords =     {Infrared Spectra, Interstellar Extinction,
+                  Ultraviolet Spectra, Visible Spectrum, Computational
+                  Astrophysics, Interstellar Matter, Iue},
+  year =         1989,
+  month =        oct,
+  volume =       345,
+  pages =        {245-256},
+  doi =          {10.1086/167900},
+  adsurl =       {http://adsabs.harvard.edu/abs/1989ApJ...345..245C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1990ApJ...361..667T,
+  author =       {{Taff}, L.~G. and {Bucciarelli}, B. and {Lattanzi},
+                  M.~G.},
+  title =        "{Catalog-to-catalog reductions}",
+  journal =      {\apj},
+  keywords =     {Astrometry, Astronomical Catalogs, Computerized
+                  Simulation, Monte Carlo Method},
+  year =         1990,
+  month =        oct,
+  volume =       361,
+  pages =        {667-672},
+  doi =          {10.1086/169230},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/1990ApJ...361..667T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1994A&A...287..338N,
+  author =       {{Nordstroem}, B. and {Latham}, D.~W. and {Morse},
+                  J.~A. and ƒ {Milone}, A.~A.~E. and {Kurucz},
+                  R.~L. and {Andersen}, J. and {Stefanik}, R.~P.},
+  title =        "{Cross-correlation radial-velocity techniques for
+                  rotating F stars}",
+  journal =      {\aap},
+  keywords =     {CROSS CORRELATION, DATA REDUCTION, F STARS, LINE
+                  SPECTRA, RADIAL VELOCITY, STELLAR MODELS, STELLAR
+                  ROTATION, ERROR ANALYSIS, PROBABILITY DENSITY
+                  FUNCTIONS, REFLECTING TELESCOPES, SPECTROGRAPHS,
+                  STELLAR ATMOSPHERES},
+  year =         1994,
+  month =        jul,
+  volume =       287,
+  pages =        {338-347},
+  adsurl =       {http://adsabs.harvard.edu/abs/1994A\%26A...287..338N},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1994ApJ...433..831B,
+  author =       {{Bucciarelli}, B. and {Lattanzi}, M.~G. and {Taff},
+                  L.~G.},
+  title =        "{The analysis of star catalogs. 1: an
+                  intercomparison among the FK3, the FK4, and the
+                  FK5}",
+  journal =      {\apj},
+  keywords =     {Astrometry, Astronomical Catalogs, Comparison, Error
+                  Analysis, Reference Stars, Statistical Analysis,
+                  Statistical Correlation},
+  year =         1994,
+  month =        oct,
+  volume =       433,
+  pages =        {831-844},
+  doi =          {10.1086/174692},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/1994ApJ...433..831B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1995A&A...304...34K,
+  author =       {{Kovalevsky}, J. and {Lindegren}, L. and
+                  {Froeschle}, M. and {van Leeuwen}, F. and
+                  {Perryman}, M.~A.~C. and {Falin}, J.~L. and
+                  {Mignard}, F. and {Penston}, M.~J. and {Petersen},
+                  C.~S. and {Bernacca}, P.~L. and {Bucciarelli},
+                  B. and {Donati}, F. and {Hering}, R. and {Hog},
+                  E. and {Lattanzi}, M.~G. and {van der Marel}, H. and
+                  {Schrijver}, H. and {Walter}, H.~G.},
+  title =        "{Construction of the intermediate HIPPARCOS
+                  astrometric catalogue}",
+  journal =      {\aap},
+  year =         1995,
+  month =        dec,
+  volume =       304,
+  pages =        {34-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1995A\%26A...304...34K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1995A&A...304...52A,
+  author =       {{Arenou}, F. and {Lindegren}, L. and {Froeschle},
+                  M. and {Gomez}, A.~E. and {Turon}, C. and
+                  {Perryman}, M.~A.~C. and {Wielen}, R.},
+  title =        "{Zero-point and external errors of HIPPARCOS
+                  parallaxes}",
+  journal =      {\aap},
+  year =         1995,
+  month =        dec,
+  volume =       304,
+  pages =        52,
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/1995A\%26A...304...52A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+% Rickman:2001
+
+@ARTICLE{1995A&A...304...61L,
+  author =       {{Lindegren}, L.},
+  title =        "{Estimating the external accuracy of HIPPARCOS
+                  parallaxes by deconvolution.}",
+  journal =      {\aap},
+  keywords =     {ASTROMETRY, METHODS: DATA ANALYSIS, METHODS:
+                  NUMERICAL, STARS: DISTANCES},
+  year =         1995,
+  month =        dec,
+  volume =       304,
+  pages =        61,
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/1995A\%26A...304...61L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% Soffel:et:al:2003
+
+@INPROCEEDINGS{1995ASPC...77..429R,
+  author =       {{Rose}, J. and {Akella}, R. and {Binegar}, S. and
+                  {Choo}, T.~H. and {Heller-Boyer}, C. and {Hester},
+                  T. and {Hyde}, P. and {Perrine}, R. and {Rose},
+                  M.~A. and {Steuerman}, K.},
+  title =        "{The OPUS Pipeline: A Partially Object-Oriented
+                  Pipeline System}",
+  booktitle =    {Astronomical Data Analysis Software and Systems IV},
+  year =         1995,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       77,
+  editor =       {{Shaw}, R.~A. and {Payne}, H.~E. and {Hayes},
+                  J.~J.~E.},
+  pages =        {429-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/1995ASPC...77..429R},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% Klioner:Soffel:2000
+
+@ARTICLE{1996A&A...305..146G,
+  author =       {{Gunn}, A.~G. and {Hall}, J.~C. and {Lockwood},
+                  G.~W. and {Doyle}, J.~G.  },
+  title =        "{Cross-correlation radial velocity measurements of
+                  chromospherically active binaries.}",
+  journal =      {\aap},
+  keywords =     {STARS: BINARIES: CLOSE, STARS: BINARIES:
+                  SPECTROSCOPIC, STARS: ACTIVITY, TECHNIQUES: RADIAL
+                  VELOCITIES},
+  year =         1996,
+  month =        jan,
+  volume =       305,
+  pages =        {146-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/1996A\%26A...305..146G},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1996PASP..108..851S,
+   author = {{Stetson}, P.~B.},
+    title = "{On the Automatic Determination of Light-Curve Parameters for Cepheid Variables}",
+  journal = {\pasp},
+ keywords = {CEPHEIDS, METHODS: NUMERICAL},
+     year = 1996,
+    month = oct,
+   volume = 108,
+    pages = {851},
+      doi = {10.1086/133808},
+   adsurl = {http://adsabs.harvard.edu/abs/1996PASP..108..851S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1997A&A...320..428H,
+  author =       {{Haywood}, M. and {Robin}, A.~C. and {Creze}, M.},
+  title =        "{The evolution of the Milky Way disc. I. Vertical
+                  structure and local constraints.}",
+  journal =      {\aap},
+  year =         1997,
+  month =        apr,
+  volume =       320,
+  pages =        {428-439},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997A\%26A...320..428H&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% Klioner:2004
+
+@ARTICLE{1997A&A...327.1253M,
+  author =       {{Moreno}, F. and {Molina}, A. and {Ortiz}, J.~L.},
+  title =        "{The 1993 south equatorial belt revival and other
+                  features in the Jovian atmosphere: an observational
+                  perspective}",
+  journal =      {\aap},
+  keywords =     {PLANETS AND SATELLITES: INDIVIDUAL: JUPITER},
+  year =         1997,
+  month =        nov,
+  volume =       327,
+  pages =        {1253-1261},
+  adsurl =       {http://adsabs.harvard.edu/abs/1997A\%26A...327.1253M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% Klioner:2003
+
+@INPROCEEDINGS{1997ESASP.402..767D,
+  author =       {{de Felice}, F. and {Lattanzi}, M.~G. and
+                  {Vecchiato}, A. and {Bernacca}, P.~L.},
+  title =        "{A Relativistic Model for the GAIA Observations}",
+  booktitle =    {Hipparcos - Venice '97},
+  year =         1997,
+  series =       {ESA Special Publication},
+  volume =       402,
+  editor =       "{R.~M.~Bonnet, E.~H{\o}g, P.~L.~Bernacca,
+                  L.~Emiliani, A.~Blaauw, C.~Turon, J.~Kovalevsky,
+                  L.~Lindegren, H.~Hassan, M.~Bouffard, B.~Strim,
+                  D.~Heger, M.~A.~C.~Perryman, \& L.~Woltjer}",
+  month =        aug,
+  pages =        {767-770},
+  adsurl =       {http://adsabs.harvard.edu/abs/1997ESASP.402..767D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+% Klioner:Peip:2003
+
+@PROCEEDINGS{1997ESASP1200.....P,
+  title =        "{The HIPPARCOS and TYCHO catalogues. Astrometric and
+                  photometric star catalogues derived from the ESA
+                  HIPPARCOS Space Astrometry Mission}",
+  keywords =     {SPACE ASTROMETRY, STAR CATALOGS, POSITIONS,
+                  ARTIFICIAL SATELLITES},
+  booktitle =    {ESA Special Publication},
+  year =         1997,
+  series =       {ESA Special Publication},
+  volume =       1200,
+  editor =       {{Perryman}, M.~A.~C. and {ESA}},
+  adsurl =       {http://adsabs.harvard.edu/abs/1997ESASP1200.....P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+% deFelice:2004
+
+@ARTICLE{1997SSRv...81..201V,
+  author =       {{van Leeuwen}, F.},
+  title =        "{The HIPPARCOS Mission}",
+  journal =      {Space Science Reviews},
+  year =         1997,
+  month =        aug,
+  volume =       81,
+  pages =        {201-409},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997SSRv...81..201V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+
+% defelice1
+
+@INPROCEEDINGS{1997hipp.conf..467E,
+  author =       {{Eyer}, L. and {Grenon}, M.},
+  title =        "{Photometric {V}ariability in the {HR} {D}iagram}",
+  booktitle =    {ESA SP-402: Hipparcos - Venice '97},
+  year =         1997,
+  pages =        {467-472},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1997hipp.conf..467E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% vecchia2
+
+@INPROCEEDINGS{1997hipp.conf..621G,
+  author =       {{Gomez}, A.~E. and {Grenier}, S. and {Udry}, S. and
+                  {Haywood}, M. and {Meillon}, L. and {Sabas}, V. and
+                  {Sellier}, A. and {Morin}, D.  },
+  title =        "{Kinematics of Disk Stars in the Solar
+                  Neighbourhood}",
+  booktitle =    {ESA SP-402: Hipparcos - Venice '97},
+  year =         1997,
+  pages =        {621-624},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1997hipp.conf..621G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% bini1
+
+@ARTICLE{1998A&A...332.1133D,
+  author =       {{de Felice}, F. and {Lattanzi}, M.~G. and
+                  {Vecchiato}, A. and {Bernacca}, P.~L.},
+  title =        "{General relativistic satellite astrometry. I. A
+                  non-perturbative approach to data reduction}",
+  journal =      {\aap},
+  keywords =     {RELATIVITY, METHODS: DATA ANALYSIS, SPACE VEHICLES,
+                  ASTROMETRY},
+  year =         1998,
+  month =        apr,
+  volume =       332,
+  pages =        {1133-1141},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998A\%26A...332.1133D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% defelice2
+
+@ARTICLE{1998A&A...340..309M,
+  author =       {{Makarov}, V.~V.},
+  title =        "{Absolute measurements of trigonometric parallaxes
+                  with astrometric satellites}",
+  journal =      {\aap},
+  year =         1998,
+  month =        dec,
+  volume =       340,
+  pages =        {309-314},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998A\%26A...340..309M},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% Lattanzi-2005:a
+
+@ARTICLE{1998A&AS..130...65L,
+  author =       {{Lejeune}, T. and {Cuisinier}, F. and {Buser}, R.},
+  title =        "{A standard stellar library for evolutionary
+                  synthesis. II. The M dwarf extension}",
+  journal =      {\aaps},
+  eprint =       {astro-ph/9710350},
+  year =         1998,
+  month =        may,
+  volume =       130,
+  pages =        {65-75},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998A\%26AS..130...65L&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{1998ApJ...503..325A,
+   author = {{Alard}, C. and {Lupton}, R.~H.},
+    title = "{A Method for Optimal Image Subtraction}",
+  journal = {\apj},
+   eprint = {astro-ph/9712287},
+ keywords = {METHODS: DATA ANALYSIS, METHODS: STATISTICAL, TECHNIQUES: IMAGE PROCESSING, Methods: Data Analysis, Methods: Statistical, Techniques: Image Processing},
+     year = 1998,
+    month = aug,
+   volume = 503,
+    pages = {325-331},
+      doi = {10.1086/305984},
+   adsurl = {http://adsabs.harvard.edu/abs/1998ApJ...503..325A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{1998ARA&A..36...99K,
+  author =       {{Kovalevsky}, J.},
+  title =        "{First Results from HIPPARCOS}",
+  journal =      {\araa},
+  year =         1998,
+  volume =       36,
+  pages =        {99-130},
+  doi =          {10.1146/annurev.astro.36.1.99},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1998ARA\%26A..36...99K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% Sozzetti-2001:a
+
+@ARTICLE{1998MNRAS.298..387D,
+  author =       {{Dehnen}, W. and {Binney}, J.~J.},
+  title =        "{Local stellar kinematics from HIPPARCOS data}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/9710077},
+  keywords =     {STARS: KINEMATICS, GALAXY: FUNDAMENTAL PARAMETERS,
+                  GALAXY: KINEMATICS AND DYNAMICS, SOLAR
+                  NEIGHBOURHOOD, GALAXY: STRUCTURE},
+  year =         1998,
+  month =        aug,
+  volume =       298,
+  pages =        {387-394},
+  doi =          {10.1046/j.1365-8711.1998.01600.x},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998MNRAS.298..387D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% paper:gaiascience
+
+@ARTICLE{1998PASP..110..863P,
+  author =       {{Pickles}, A.~J.},
+  title =        "{A Stellar Spectral Flux Library: 1150-25000 {\AA}}",
+  journal =      {\pasp},
+  keywords =     {ATLASES, STARS: GENERAL, GALAXIES: STELLAR CONTENT},
+  year =         1998,
+  month =        jul,
+  volume =       110,
+  pages =        {863-878},
+  doi =          {10.1086/316197},
+  adsurl =       {http://adsabs.harvard.edu/abs/1998PASP..110..863P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% Lattanzi-2000:a
+
+@ARTICLE{1999A&AS..137..521M,
+  author =       {{Munari}, U. and {Tomasella}, L.},
+  title =        "{High resolution spectroscopy over lambda lambda
+                  8500-8750 {\AA} for GAIA. I. Mapping the MKK
+                  classification system}",
+  journal =      {\aaps},
+  year =         1999,
+  month =        jun,
+  volume =       137,
+  pages =        {521-528},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=1999A\%26AS..137..521M&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% kov1
+
+@ARTICLE{1999BaltA...8...57O,
+  author =       {{O'Mullane}, W. and {Lindegren}, L.},
+  title =        "{An Object-Oriented Framework for GAIA Data
+                  Processing}",
+  journal =      {Baltic Astronomy},
+  year =         1999,
+  volume =       8,
+  pages =        {57-72},
+  adsurl =       {http://adsabs.harvard.edu/abs/1999BaltA...8...57O},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% Pourbaix-2002:b
+
+@ARTICLE{1999MNRAS.310..645W,
+  author =       {{Wilkinson}, M.~I. and {Evans}, N.~W.},
+  title =        "{The present and future mass of the Milky Way halo}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/9906197},
+  year =         1999,
+  month =        dec,
+  volume =       310,
+  pages =        {645-662},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=1999MNRAS.310..645W&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+
+% Smolcic-2004:a
+
+@ARTICLE{2000A&A...354..522M,
+  author =       {{Mignard}, F.},
+  title =        "{Local galactic kinematics from Hipparcos proper
+                  motions}",
+  journal =      {\aap},
+  keywords =     {ASTROMETRY, CELESTIAL MECHANICS, STELLAR DYNAMICS,
+                  GALAXY: KINEMATICS AND DYNAMICS, GALAXY: SOLAR
+                  NEIGHBOURHOOD},
+  year =         2000,
+  month =        feb,
+  volume =       354,
+  pages =        {522-536},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000A\%26A...354..522M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% Bretagnon1988
+
+@ARTICLE{2000A&A...355L..27H,
+  author =       {{H{\o}g}, E. and {Fabricius}, C. and {Makarov},
+                  V.~V. and {Urban}, S. and {Corbin}, T. and {Wycoff},
+                  G. and {Bastian}, U. and {Schwekendiek}, P. and
+                  {Wicenec}, A.},
+  title =        "{The Tycho-2 catalogue of the 2.5 million brightest
+                  stars}",
+  journal =      {\aap},
+  keywords =     {ASTROMETRY, STARS: FUNDAMENTAL PARAMETERS, CATALOGS},
+  year =         2000,
+  month =        mar,
+  volume =       355,
+  pages =        {L27-L30},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000A\%26A...355L..27H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% Bretagnon1982
+
+@ARTICLE{2000A&AS..143...33B,
+  author =       {{Bonnarel}, F. and {Fernique}, P. and
+                  {Bienaym{\'e}}, O. and {Egret}, D. and {Genova},
+                  F. and {Louys}, M. and {Ochsenbein}, F. and
+                  {Wenger}, M. and {Bartlett}, J.~G.},
+  title =        "{The ALADIN interactive sky atlas. A reference tool
+                  for identification of astronomical sources}",
+  journal =      {\aaps},
+  keywords =     {ASTRONOMICAL DATA BASES: MISCELLANEOUS, CATALOGS,
+                  ATLASES, SURVEYS},
+  year =         2000,
+  month =        apr,
+  volume =       143,
+  pages =        {33-40},
+  doi =          {10.1051/aas:2000331},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000A\%26AS..143...33B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+% Simon1983
+
+@INPROCEEDINGS{2000ASPC..203...71E,
+  author =       {{Eyer}, L. and {Cuypers}, J.},
+  title =        "{Predictions on the Number of Variable Stars for the
+                  GAIA Space Mission and for Surveys such as the
+                  Ground-Based International Liquid Mirror Telescope}",
+  booktitle =    {ASP Conf. Ser. 203: IAU Colloq. 176: The Impact of
+                  Large-Scale Surveys on Pulsating Star Research},
+  year =         2000,
+  editor =       {{Szabados}, L. and {Kurtz}, D.},
+  pages =        {71-72},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2000ASPC..203...71E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% astro:besanconmodel
+
+@INPROCEEDINGS{2000ASPC..216..419O,
+  author =       {{O'Mullane}, W. and {Hazell}, A. and {Bennett},
+                  K. and {Bartelmann}, M. and {Vuerli}, C.},
+  title =        "{ESA Survey Missions and Global Processing}",
+  booktitle =    {Astronomical Data Analysis Software and Systems IX},
+  year =         2000,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       216,
+  editor =       {{Manset}, N. and {Veillet}, C. and {Crabtree}, D.},
+  pages =        {419-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000ASPC..216..419O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% astro:extinctionmodel
+
+@INPROCEEDINGS{2000ASSL..252..201G,
+  author =       {{Groom}, D.~E. and {Eberhard}, P.~H. and {Holland},
+                  S.~E. and {Levi}, M.~E. and {Palaio}, N.~P. and
+                  {Perlmutter}, S. and {Stover}, R.~J. and {Wei}, M.},
+  title =        "{Point-spread function in depleted and partially
+                  depleted CCDs}",
+  booktitle =    {Astrophysics and Space Science Library},
+  year =         2000,
+  series =       {Astrophysics and Space Science Library},
+  volume =       252,
+  editor =       "{P.~Amico \& J.~W.~Beletic}",
+  pages =        {201-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000ASSL..252..201G},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2000ApJ...536..571B,
+   author = {{Ben{\'{\i}}tez}, N.},
+    title = "{Bayesian Photometric Redshift Estimation}",
+  journal = {\apj},
+   eprint = {astro-ph/9811189},
+ keywords = {Galaxies: Distances and Redshifts, Galaxies: Photometry, Methods: Statistical},
+     year = 2000,
+    month = jun,
+   volume = 536,
+    pages = {571-583},
+      doi = {10.1086/308947},
+   adsurl = {http://adsabs.harvard.edu/abs/2000ApJ...536..571B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2000MNRAS.317..211L,
+  author =       {{Lattanzi}, M.~G. and {Spagna}, A. and {Sozzetti},
+                  A. and {Casertano}, S.  },
+  title =        "{Space-borne global astrometric surveys: the hunt
+                  for extrasolar planets}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0005024},
+  year =         2000,
+  month =        sep,
+  volume =       317,
+  pages =        {211-224},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2000MNRAS.317..211L&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% gomez1997
+
+@ARTICLE{2000MNRAS.319..657H,
+  author =       {{Helmi}, A. and {de Zeeuw}, P.~T.},
+  title =        "{Mapping the substructure in the Galactic halo with
+                  the next generation of astrometric satellites}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0007166},
+  year =         2000,
+  month =        dec,
+  volume =       319,
+  pages =        {657-665},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2000MNRAS.319..657H&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% cu6:skew_technique
+
+@ARTICLE{2000PhRvD..62b4019K,
+  author =       {{Klioner}, S.~A. and {Soffel}, M.~H.},
+  title =        "{Relativistic celestial mechanics with PPN
+                  parameters}",
+  journal =      {\prd},
+  eprint =       {gr-qc/9906123},
+  year =         2000,
+  month =        jul,
+  volume =       62,
+  number =       2,
+  pages =        {024019-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2000PhRvD..62b4019K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% koval98
+
+@INPROCEEDINGS{2000SPIE.4013..453G,
+  author =       {{Gilmore}, G.~F. and {de Boer}, K.~S. and {Favata},
+                  F. and {Hoeg}, E. and {Lattanzi}, M.~G. and
+                  {Lindegren}, L. and {Luri}, X. and {Mignard}, F. and
+                  {Perryman}, M.~A. and {de Zeeuw}, P.~T.},
+  title =        "{GAIA: origin and evolution of the Milky Way}",
+  booktitle =    {Proc. SPIE Vol. 4013, p. 453-472, UV, Optical, and
+                  IR Space Telescopes and Instruments, James
+                  B. Breckinridge; Peter Jakobsen; Eds.},
+  year =         2000,
+  series =       {Presented at the Society of Photo-Optical
+                  Instrumentation Engineers (SPIE) Conference},
+  volume =       4013,
+  editor =       {{Breckinridge}, J.~B. and {Jakobsen}, P.},
+  month =        jul,
+  pages =        {453-472},
+  adsurl =       {http://adsabs.harvard.edu/abs/2000SPIE.4013..453G},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% paper:hipquality
+
+@ARTICLE{2001A&A...369..339P,
+  author =       {{Perryman}, M.~A.~C. and {de Boer}, K.~S. and
+                  {Gilmore}, G. and {H{\o}g}, E. and {Lattanzi},
+                  M.~G. and {Lindegren}, L. and {Luri}, X. and
+                  {Mignard}, F. and {Pace}, O. and {de Zeeuw}, P.~T.},
+  title =        "{GAIA: Composition, formation and evolution of the
+                  Galaxy}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0101235},
+  year =         2001,
+  month =        apr,
+  volume =       369,
+  pages =        {339-363},
+  doi =          {10.1051/0004-6361:20010085},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A\%26A...369..339P&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% paper:hipreproc
+
+@ARTICLE{2001A&A...373..336D,
+  author =       {{de Felice}, F. and {Bucciarelli}, B. and
+                  {Lattanzi}, M.~G. and {Vecchiato}, A.},
+  title =        "{General relativistic satellite
+                  astrometry. II. Modeling parallax and proper
+                  motion}",
+  journal =      {\aap},
+  year =         2001,
+  month =        jul,
+  volume =       373,
+  pages =        {336-344},
+  doi =          {10.1051/0004-6361:20010499},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A\%26A...373..336D&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% fvl97
+
+@ARTICLE{2001A&A...373L..21S,
+  author =       {{Sozzetti}, A. and {Casertano}, S. and {Lattanzi},
+                  M.~G. and {Spagna}, A.},
+  title =        "{Detection and measurement of planetary systems with
+                  GAIA}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0104391},
+  year =         2001,
+  month =        jul,
+  volume =       373,
+  pages =        {L21-L24},
+  doi =          {10.1051/0004-6361:20010788},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001A\%26A...373L..21S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% paper:RBBdL06
+
+@INPROCEEDINGS{2001ASPC..225..201O,
+  author =       {{O'Mullane}, W. and {Luri}, X.},
+  title =        "{GAIA and Virtual Observatories}",
+  booktitle =    {Virtual Observatories of the Future},
+  year =         2001,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       225,
+  editor =       {{Brunner}, R.~J. and {Djorgovski}, S.~G. and
+                  {Szalay}, A.~S.  },
+  pages =        201,
+  adsurl =       {http://adsabs.harvard.edu/abs/2001ASPC..225..201O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% helmi2000
+
+@ARTICLE{2001ApJ...556..181D,
+  author =       {{Drimmel}, R. and {Spergel}, D.~N.},
+  title =        "{Three-dimensional Structure of the Milky Way Disk:
+                  The Distribution of Stars and Dust beyond 0.35
+                  R_{solar}}",
+  journal =      {\apj},
+  year =         2001,
+  month =        jul,
+  volume =       556,
+  pages =        {181-202},
+  doi =          {10.1086/321556},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001ApJ...556..181D&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+
+% pickles1998
+
+@ARTICLE{2001IAUTr..24B....R,
+  author =       {{Rickman}, H.},
+  title =        "{Transactions of the International Astronomical
+                  Union Proceedings of the Twenty-Fourth General
+                  Assembly.}",
+  journal =      {Transactions of the International Astronomical Union
+                  Proceedings of the Twenty-Fourth General
+                  Assembly.~Editedy by Hans Rickman.~ ISBN:
+                  1-58381-087-0.~San Francisco: Astronomical Society
+                  of the Pacific, 2001.},
+  year =         2001,
+  volume =       24,
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2001IAUTr..24B....R&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2001PASP..113.1420V,
+  author =       {{van Dokkum}, P.~G.},
+  title =        "{Cosmic-Ray Rejection by Laplacian Edge Detection}",
+  journal =      {\pasp},
+  eprint =       {astro-ph/0108003},
+keywords =       {Instrumentation: Detectors,
+                  Methods: Data Analysis-techniques: image processing},
+  year =         2001,
+  month =        nov,
+  volume =       113,
+  pages =        {1420-1427},
+  doi =          {10.1086/323894},
+  adsurl =       {http://adsabs.harvard.edu/abs/2001PASP..113.1420V},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2001astro.ph..7457K,
+  author =       {{Klioner}, S.~A.},
+  title =        "{A Practical Relativistic Model of Microarcsecond
+                  Astrometry in Space}",
+  journal =      {ArXiv Astrophysics e-prints},
+  eprint =       {astro-ph/0107457},
+  year =         2001,
+  month =        jul,
+  adsurl =       {http://adsabs.harvard.edu/abs/2001astro.ph..7457K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2001misk.conf..631K,
+   author = {{Kunszt}, P.~Z. and {Szalay}, A.~S. and {Thakar}, A.~R.},
+    title = "{The Hierarchical Triangular Mesh}",
+booktitle = {Mining the Sky},
+     year = 2001,
+   editor = {{Banday}, A.~J. and {Zaroubi}, S. and {Bartelmann}, M.},
+    pages = {631},
+      doi = {10.1007/10849171_83},
+   adsurl = {http://adsabs.harvard.edu/abs/2001misk.conf..631K},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@BOOK{2001sccd.book.....J,
+  author =       {{Janesick}, J.~R.},
+  title =        "{Scientific charge-coupled devices}",
+  keywords =     {CHARGE COUPLED DEVICES, OPTICAL INSTRUMENTS},
+  booktitle =    {Scientific charge-coupled devices, Bellingham, WA:
+                  SPIE Optical Engineering Press, 2001, xvi, 906
+                  p.~SPIE Press monograph, PM 83.~ISBN 0819436984},
+  year =         2001,
+  publisher =    {SPIE Optical Engineering Press},
+  adsurl =       {http://adsabs.harvard.edu/abs/2001sccd.book.....J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% wilkinson1999
+
+@ARTICLE{2002A&A...385..686P,
+  author =       {{Pourbaix}, D.},
+  title =        "{Precision and accuracy of the orbital parameters
+                  derived from 2D {\amp} 1D space observations of
+                  visual or astrometric binaries}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0201132},
+  year =         2002,
+  month =        apr,
+  volume =       385,
+  pages =        {686-692},
+  doi =          {10.1051/0004-6361:20020149},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002A\%26A...385..686P&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% wilkinson2004a
+
+@INPROCEEDINGS{2002ASPC..259..160E,
+  author =       {{Eyer}, L. and {Blake}, C.},
+  title =        "{Automated Classification of Variable Stars for ASAS
+                  Data}",
+  booktitle =    {ASP Conf. Ser. 259: IAU Colloq. 185: Radial and
+                  Nonradial Pulsationsn as Probes of Stellar Physics},
+  year =         2002,
+  editor =       {{Aerts}, C. and {Bedding}, T.~R. and
+                  {Christensen-Dalsgaard}, J.  },
+  pages =        {160-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2002ASPC..259..160E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% wilkinson2004b
+
+@ARTICLE{2002AcA....52..241E,
+  author =       {{Eyer}, L.},
+  title =        "{Search for QSO Candidates in OGLE-II Data}",
+  journal =      {Acta Astronomica},
+  eprint =       {astro-ph/0206074},
+  year =         2002,
+  month =        sep,
+  volume =       52,
+  pages =        {241-262},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002AcA....52..241E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2002AJ....123..583B,
+   author = {{Bernstein}, G.~M. and {Jarvis}, M.},
+    title = "{Shapes and Shears, Stars and Smears: Optimal Measurements for Weak Lensing}",
+  journal = {\aj},
+   eprint = {astro-ph/0107431},
+ keywords = {Cosmology: Gravitational Lensing, Methods: Data Analysis, Techniques: Image Processing},
+     year = 2002,
+    month = feb,
+   volume = 123,
+    pages = {583-618},
+      doi = {10.1086/338085},
+   adsurl = {http://adsabs.harvard.edu/abs/2002AJ....123..583B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2002Ap&SS.280...21B,
+  author =       {{Bailer-Jones}, C.~A.~L.},
+  title =        "{Determination of Stellar Parameters with GAIA}",
+  journal =      {Astrophysics and Space Science},
+  eprint =       {astro-ph/0201014},
+  year =         2002,
+  volume =       280,
+  pages =        {21-29},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Ap\%26SS.280...21B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% paper:tdi
+
+@INPROCEEDINGS{2002EAS.....2..107M,
+  author =       {{Mignard}, F.},
+  title =        "{Fundamental Physics with GAIA}",
+  booktitle =    {EAS Publications Series},
+  year =         2002,
+  series =       {Engineering and Science},
+  volume =       2,
+  editor =       {{Bienayme}, O. and {Turon}, C.},
+  pages =        {107-121},
+  adsurl =       {http://adsabs.harvard.edu/abs/2002EAS.....2..107M},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2002Icar..158..106B,
+  author =       {{Bus}, S.~J. and {Binzel}, R.~P.},
+  title =        "{Phase II of the Small Main-Belt Asteroid
+                  Spectroscopic SurveyThe Observations}",
+  journal =      {Icarus},
+  year =         2002,
+  month =        jul,
+  volume =       158,
+  pages =        {106-145},
+  doi =          {10.1006/icar.2002.6857},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Icar..158..106B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% defelice3
+
+@ARTICLE{2002Icar..158..146B,
+  author =       {{Bus}, S.~J. and {Binzel}, R.~P.},
+  title =        "{Phase II of the Small Main-Belt Asteroid
+                  Spectroscopic SurveyA Feature-Based Taxonomy}",
+  journal =      {Icarus},
+  year =         2002,
+  month =        jul,
+  volume =       158,
+  pages =        {146-177},
+  doi =          {10.1006/icar.2002.6856},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2002Icar..158..146B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% busonero1
+
+@INPROCEEDINGS{2002SPIE.4836..333S,
+  author =       {{Szalay}, A.~S. and {Gray}, J. and {VandenBerg}, J.},
+  title =        "{Petabyte Scale Data Mining: Dream or Reality?}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2002,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       4836,
+  eprint =       {arXiv:cs/0208013},
+  editor =       "{J.~A.~Tyson \& S.~Wolff}",
+  month =        dec,
+  pages =        {333-338},
+  doi =          {10.1117/12.461427},
+  adsurl =       {http://adsabs.harvard.edu/abs/2002SPIE.4836..333S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% gai2
+
+@ARTICLE{2002cs........2013S,
+  author =       {{Szalay}, A.~S. and {Gray}, J. and {Thakar},
+                  A.~R. and {Kunszt}, P.~Z. and {Malik}, T. and
+                  {Raddick}, J. and {Stoughton}, C. and {vandenBerg},
+                  J.  },
+  title =        "{The SDSS SkyServer: Public Access to the Sloan
+                  Digital Sky Server Data}",
+  journal =      {eprint arXiv:cs/0202013},
+  eprint =       {arXiv:cs/0202013},
+  keywords =     {Computer Science - Digital Libraries, Computer
+                  Science - Databases, H.3.7, H.3.5, H.2, H.3, H.4,
+                  H.5},
+  year =         2002,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2002cs........2013S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% paper:jfc06QSO
+
+@ARTICLE{2003A&A...399..337V,
+  author =       {{Vecchiato}, A. and {Lattanzi}, M.~G. and
+                  {Bucciarelli}, B. and {Crosta}, M. and {de Felice},
+                  F. and {Gai}, M.},
+  title =        "{Testing general relativity by micro-arcsecond
+                  global astrometry}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0301323},
+  year =         2003,
+  month =        feb,
+  volume =       399,
+  pages =        {337-342},
+  doi =          {10.1051/0004-6361:20021785},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A\%26A...399..337V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% paper:gtr04QSO
+
+@ARTICLE{2003A&A...409..523R,
+  author =       {{Robin}, A.~C. and {Reyl{\'e}}, C. and
+                  {Derri{\`e}re}, S. and {Picaud}, S.},
+  title =        "{A synthetic view on structure and evolution of the
+                  Milky Way}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0401052},
+  year =         2003,
+  month =        oct,
+  volume =       409,
+  pages =        {523-540},
+  doi =          {10.1051/0004-6361:20031117},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A\%26A...409..523R&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% paper:le02QSO
+
+@ARTICLE{2003A&A...410.1063K,
+  author =       {{Klioner}, S.~A. and {Peip}, M.},
+  title =        "{Numerical simulations of the light propagation in
+                  the gravitational field of moving bodies}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0305204},
+  year =         2003,
+  month =        nov,
+  volume =       410,
+  pages =        {1063-1074},
+  doi =          {10.1051/0004-6361:20031283},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003A\%26A...410.1063K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% munari1999
+
+@ARTICLE{2003A&A...412..105M,
+  author =       {{Moniez}, M.},
+  title =        "{Does transparent hidden matter generate optical
+                  scintillation?}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0302460},
+  keywords =     {cosmology: dark matter, Galaxy: disk, Galaxy: halo,
+                  ISM: clouds, ISM: molecules},
+  year =         2003,
+  month =        dec,
+  volume =       412,
+  pages =        {105-120},
+  doi =          {10.1051/0004-6361:20031478},
+  adsurl =       {http://adsabs.harvard.edu/abs/2003A\%26A...412..105M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% paper:sozzrev
+
+@ARTICLE{2003AJ....125.1580K,
+  author =       {{Klioner}, S.~A.},
+  title =        "{A Practical Relativistic Model for Microarcsecond
+                  Astrometry in Space}",
+  journal =      {\aj},
+  year =         2003,
+  month =        mar,
+  volume =       125,
+  pages =        {1580-1597},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003AJ....125.1580K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% paper:c1bc1m
+
+@ARTICLE{2003AJ....126.2687S,
+  author =       {{Soffel}, M. and {Klioner}, S.~A. and {Petit},
+                  G. and {Wolf}, P. and {Kopeikin}, S.~M. and
+                  {Bretagnon}, P. and {Brumberg},
+                  V.~A. and1998A&A...340..309M1998A&A...340..309M
+                  {Capitaine}, N. and {Damour}, T. and {Fukushima},
+                  T. and {Guinot}, B. and {Huang}, T.-Y. and
+                  {Lindegren}, L. and {Ma}, C. and {Nordtvedt}, K. and
+                  {Ries}, J.~C. and {Seidelmann}, P.~K. and
+                  {Vokrouhlick{\'y}}, D. and {Will}, C.~M. and {Xu},
+                  C.},
+  title =        "{The IAU 2000 Resolutions for Astrometry, Celestial
+                  Mechanics, and Metrology in the Relativistic
+                  Framework: Explanatory Supplement}",
+  journal =      {\aj},
+  eprint =       {astro-ph/0303376},
+  year =         2003,
+  month =        dec,
+  volume =       126,
+  pages =        {2687-2706},
+  doi =          {10.1086/378162},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003AJ....126.2687S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% brettetal2004
+
+@INPROCEEDINGS{2003ASPC..295..261M,
+  author =       {{Miller}, III, W.~W. and {Sontag}, C. and {Rose},
+                  J.~F.},
+  title =        "{OPUS: A CORBA Pipeline for Java, Python, and Perl
+                  Applications}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XII},
+  year =         2003,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       295,
+  editor =       {{Payne}, H.~E. and {Jedrzejewski}, R.~I. and {Hook},
+                  R.~N.},
+  pages =        {261-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2003ASPC..295..261M},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% evansbelokurov2005
+
+@INPROCEEDINGS{2003ASPC..298..199B,
+  author =       {{Bailer-Jones}, C.~A.~L.},
+  title =        "{On the classification and parametrization of GAIA
+                  data using pattern recognition methods}",
+  booktitle =    {GAIA Spectroscopy: Science and Technology},
+  year =         2003,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       298,
+  editor =       {{Munari}, U.},
+  pages =        {199-+},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/2003ASPC..298..199B},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% eyergrenon1997
+
+@ARTICLE{2003CQGra..20.4695B,
+  author =       {{Bini}, D. and {Crosta}, M.~T. and {de Felice}, F.},
+  title =        "{Orbiting frames and satellite attitudes in
+                  relativistic astrometry}",
+  journal =      {Classical and Quantum Gravity},
+  year =         2003,
+  month =        nov,
+  volume =       20,
+  pages =        {4695-4706},
+  doi =          {10.1088/0264-9381/20/21/009},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003CQGra..20.4695B&db_key=PHY},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% eyercuypers2000
+
+@ARTICLE{2003MNRAS.342..151V,
+  author =       {{Vande Putte}, D. and {Smith}, R.~C. and {Hawkins},
+                  N.~A. and {Martin}, J.~S.},
+  title =        "{A spectroscopic search for faint secondaries in
+                  cataclysmic variables}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0302507},
+  year =         2003,
+  month =        jun,
+  volume =       342,
+  pages =        {151-162},
+  doi =          {10.1046/j.1365-8711.2003.06524.x},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2003MNRAS.342..151V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% eyerblake2002
+
+@ARTICLE{2004A&A...419..385B,
+  author =       {{Bailer-Jones}, C.~A.~L.},
+  title =        "{Evolutionary design of photometric systems and its
+                  application to Gaia}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0402591},
+  year =         2004,
+  month =        may,
+  volume =       419,
+  pages =        {385-403},
+  doi =          {10.1051/0004-6361:20035779},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004A\%26A...419..385B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% eyer2005
+
+@INPROCEEDINGS{2004ASPC..314..293Y,
+  author =       {{Yasuda}, N. and {Mizumoto}, Y. and {Ohishi}, M. and
+                  {O'Mullane}, W. and {Budav{\'a}ri}, T. and
+                  {Haridas}, V. and {Li}, N. and {Malik}, T. and
+                  {Szalay}, A.~S. and {Hill}, M. and {Linde}, T. and
+                  {Mann}, B. and {Page}, C.~G.},
+  title =        "{Astronomical Data Query Language: Simple Query
+                  Protocol for the Virtual Observatory}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  (ADASS) XIII},
+  year =         2004,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       314,
+  editor =       "{F.~Ochsenbein, M.~G.~Allen, \& D.~Egret}",
+  month =        jul,
+  pages =        293,
+  adsurl =       {http://adsabs.harvard.edu/abs/2004ASPC..314..293Y},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% eyerblake2005
+
+@INPROCEEDINGS{2004ASPC..314..376W,
+  author =       {{Wieprecht}, E. and {Brumfit}, J. and {Bakker},
+                  J. and {de Candussio}, N. and {Guest}, S. and
+                  {Huygen}, R. and {de Jonge}, A. and {Matthieu},
+                  J.~J. and {Osterhage}, S. and {Ott}, S. and
+                  {Siddiqui}, H. and {Vandenbussche}, B. and {de
+                  Meester}, W. and {Wetzstein}, M. and {Wiezorrek},
+                  E. and {Zaal}, P.},
+  title =        "{The HERSCHEL/PACS Common Software System as Data
+                  Reduction System}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  (ADASS) XIII},
+  year =         2004,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       314,
+  editor =       {{Ochsenbein}, F. and {Allen}, M.~G. and {Egret}, D.},
+  month =        jul,
+  pages =        {376-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2004ASPC..314..376W},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% eyermignard2005
+
+@INPROCEEDINGS{2004ASPC..314..585P,
+  author =       {{Plante}, R. and {Greene}, G. and {Hanisch}, R. and
+                  {McGlynn}, T. and {O'Mullane}, W. and {Williamson},
+                  R.},
+  title =        "{Resource Registries for the Virtual Observatory}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  (ADASS) XIII},
+  year =         2004,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       314,
+  editor =       "{F.~Ochsenbein, M.~G.~Allen, \& D.~Egret}",
+  month =        jul,
+  pages =        585,
+  adsurl =       {http://adsabs.harvard.edu/abs/2004ASPC..314..585P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+% eyer2006a
+
+@ARTICLE{2004ApJ...607..580D,
+  author =       {{de Felice}, F. and {Crosta}, M.~T. and {Vecchiato},
+                  A. and {Lattanzi}, M.~G. and {Bucciarelli}, B.},
+  title =        "{A General Relativistic Model of Light Propagation
+                  in the Gravitational Field of the Solar System: The
+                  Static Case}",
+  journal =      {\apj},
+  eprint =       {astro-ph/0401637},
+  year =         2004,
+  month =        may,
+  volume =       607,
+  pages =        {580-595},
+  doi =          {10.1086/383244},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004ApJ...607..580D&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% eyer2006b
+
+@ARTICLE{2004ApJ...615L.141S,
+  author =       {{Smol{\v c}i{\'c}}, V. and {Ivezi{\'c}}, {\v Z}. and
+                  {Knapp}, G.~R. and {Lupton}, R.~H. and {Pavlovski},
+                  K. and {Iliji{\'c}}, S. and {Schlegel}, D. and
+                  {Smith}, J.~A. and {McGehee}, P.~M. and {Silvestri},
+                  N.~M. and {Hawley}, S.~L. and {Rockosi}, C. and
+                  {Gunn}, J.~E. and {Strauss}, M.~A. and {Fan}, X. and
+                  {Eisenstein}, D. and {Harris}, H.},
+  title =        "{A Second Stellar Color Locus: a Bridge from White
+                  Dwarfs to M stars}",
+  journal =      {\apjl},
+  eprint =       {astro-ph/0403218},
+  year =         2004,
+  month =        nov,
+  volume =       615,
+  pages =        {L141-L144},
+  doi =          {10.1086/426475},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004ApJ...615L.141S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% protopapasetal2006
+
+@ARTICLE{2004ApJS..155..257R,
+  author =       {{Richards}, G.~T. and {Nichol}, R.~C. and {Gray},
+                  A.~G. and {Brunner}, R.~J. and {Lupton}, R.~H. and
+                  {Vanden Berk}, D.~E. and {Chong}, S.~S. and
+                  {Weinstein}, M.~A. and {Schneider}, D.~P. and
+                  {Anderson}, S.~F. and {Munn}, J.~A. and {Harris},
+                  H.~C. and {Strauss}, M.~A. and {Fan}, X. and {Gunn},
+                  J.~E. and {Ivezi{\'c}}, {\v Z}. and {York},
+                  D.~G. and {Brinkmann}, J. and {Moore}, A.~W.},
+  title =        "{Efficient Photometric Selection of Quasars from the
+                  Sloan Digital Sky Survey: 100,000 z {\lt} 3 Quasars
+                  from Data Release One}",
+  journal =      {\apjs},
+  eprint =       {astro-ph/0408505},
+  year =         2004,
+  month =        dec,
+  volume =       155,
+  pages =        {257-269},
+  doi =          {10.1086/425356},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004ApJS..155..257R&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% moniez2003
+
+@ARTICLE{2004MNRAS.353..369B,
+  author =       {{Brett}, D.~R. and {West}, R.~G. and {Wheatley},
+                  P.~J.},
+  title =        "{The automated classification of astronomical light
+                  curves using {K}ohonen self-organizing maps}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0408118},
+  year =         2004,
+  month =        sep,
+  volume =       353,
+  pages =        {369-376},
+  doi =          {10.1111/j.1365-2966.2004.08093.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2004MNRAS.353..369B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% cu8:cbjparis
+
+@ARTICLE{2004PhR...400..209K,
+  author =       {{Kopeikin}, S. and {Vlasov}, I.},
+  title =        "{Parametrized post-Newtonian theory of reference
+                  frames, multipolar expansions and equations of
+                  motion in the N-body problem}",
+  journal =      {\physrep},
+  eprint =       {gr-qc/0403068},
+  year =         2004,
+  month =        nov,
+  volume =       400,
+  pages =        {209-318},
+  doi =          {10.1016/j.physrep.2004.08.004},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004PhR...400..209K&db_key=PHY},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% cu8:cbjhfd
+
+@ARTICLE{2004PhRvD..69l4001K,
+  author =       {{Klioner}, S.~A.},
+  title =        "{Physically adequate proper reference system of a
+                  test observer and relativistic description of the
+                  GAIA attitude}",
+  journal =      {Phys. Rev. D},
+  eprint =       {astro-ph/0311540},
+  year =         2004,
+  month =        jun,
+  volume =       69,
+  number =       12,
+  pages =        {124001-+},
+  doi =          {10.1103/PhysRevD.69.124001},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004PhRvD..69l4001K&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% cu8:cbjvilnius
+
+@INPROCEEDINGS{2004SPIE.5494..529B,
+  author =       {{Baccaro}, S. and {Cecilia}, A. and {Di Sarcina},
+                  I. and {Piegari}, A.~M.  },
+  title =        "{Optical coating behavior under y irradiation for
+                  space applications}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2004,
+  series =       {Presented at the Society of Photo-Optical
+                  Instrumentation Engineers (SPIE) Conference},
+  volume =       5494,
+  editor =       "{E.~Atad-Ettedgui \& P.~Dierickx}",
+  month =        sep,
+  pages =        {529-535},
+  doi =          {10.1117/12.553602},
+  adsurl =       {http://adsabs.harvard.edu/abs/2004SPIE.5494..529B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% cu8:baselmethod
+
+@INPROCEEDINGS{2004SPIE.5495...23J,
+  author =       {{Jessen}, N.~C. and {N{\o}rgaard-Nielsen}, H.~U. and
+                  {Stevenson}, T. and {Sykes}, J. and {Schroll},
+                  J. and {Hastings}, P.},
+  title =        "{The CFRP primary structure of the MIRI instrument
+                  onboard the James Webb Space Telescope}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2004,
+  series =       {Presented at the Society of Photo-Optical
+                  Instrumentation Engineers (SPIE) Conference},
+  volume =       5495,
+  editor =       "{J.~Antebi \& D.~Lemke}",
+  month =        sep,
+  pages =        {23-30},
+  doi =          {10.1117/12.550023},
+  adsurl =       {http://adsabs.harvard.edu/abs/2004SPIE.5495...23J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% mpclass:bus2002b
+
+@INPROCEEDINGS{2004SPIE.5497..461G,
+  author =       {{Gardiol}, D. and {Loreggia}, D. and {Mannu}, S. and
+                  {Mottini}, S. and {Perachino}, L. and {Gai}, M. and
+                  {Lattanzi}, M.~G.},
+  title =        "{End-to-end optomechanical simulation for
+                  high-precision global astrometry}",
+  booktitle =    {Modeling and Systems Engineering for Astronomy.
+                  Edited by Craig, Simon C.; Cullum, Martin J.
+                  Proceedings of the SPIE, Volume 5497, pp. 461-470
+                  (2004).},
+  year =         2004,
+  editor =       {{Craig}, S.~C. and {Cullum}, M.~J.},
+  month =        sep,
+  pages =        {461-470},
+  doi =          {10.1117/12.550356},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2004SPIE.5497..461G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% mpclass:bus2002a
+
+@ARTICLE{2005A&A...438..745B,
+  author =       {{Bastian}, U. and {Biermann}, M.},
+  title =        "{Astrometric meaning and interpretation of
+                  high-precision time delay integration CCD data}",
+  journal =      {\aap},
+  year =         2005,
+  month =        aug,
+  volume =       438,
+  pages =        {745-755},
+  doi =          {10.1051/0004-6361:20042372},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A\%26A...438..745B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% mpclass:Zellner
+
+@ARTICLE{2005A&A...439..791V,
+  author =       {{van Leeuwen}, F. and {Fantino}, E.},
+  title =        "{A new reduction of the raw Hipparcos data}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0505432},
+  year =         2005,
+  month =        aug,
+  volume =       439,
+  pages =        {791-803},
+  doi =          {10.1051/0004-6361:20053193},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A\%26A...439..791V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% cu3:Bruen
+
+@ARTICLE{2005A&A...439..805V,
+  author =       {{van Leeuwen}, F.},
+  title =        "{Rights and wrongs of the Hipparcos data. A critical
+                  quality assessment of the Hipparcos catalogue}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0505431},
+  year =         2005,
+  month =        aug,
+  volume =       439,
+  pages =        {805-822},
+  doi =          {10.1051/0004-6361:20053192},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005A\%26A...439..805V&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+% conf:gaiascience
+
+@ARTICLE{2005ApJ...622..759G,
+  author =       {{G{\'o}rski}, K.~M. and {Hivon}, E. and {Banday},
+                  A.~J. and {Wandelt}, B.~D. and {Hansen}, F.~K. and
+                  {Reinecke}, M. and {Bartelmann}, M.},
+  title =        "{HEALPix: A Framework for High-Resolution
+                  Discretization and Fast Analysis of Data Distributed
+                  on the Sphere}",
+  journal =      {\apj},
+  eprint =       {arXiv:astro-ph/0409513},
+  keywords =     {Cosmology: Cosmic Microwave Background, Cosmology:
+                  Observations, Methods: Statistical},
+  year =         2005,
+  month =        apr,
+  volume =       622,
+  pages =        {759-771},
+  doi =          {10.1086/427976}
+}
+
+%conf:gaiaeurospaceproject
+
+@PROCEEDINGS{2005ESASP.576.....T,
+  title =        "{The Three-Dimensional Universe with Gaia}",
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576.....T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% conf:inpopephem
+
+@INPROCEEDINGS{2005ESASP.576...29L,
+  author =       {{Lindegren}, L.},
+  title =        "{The Astrometric Instrument of Gaia: Principles}",
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C. },
+  month =        jan,
+  pages =        {29-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576...29L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% cu5:photometry-paris
+
+@INPROCEEDINGS{2005ESASP.576...67D,
+  author =       {{de Bruijne}, J.~H.~J. and {Lammers}, U. and
+                  {Perryman}, M.~A.~C.  },
+  title =        "{The Gaia Parameter Database}",
+  keywords =     {Gaia, Reference Values, Database},
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       "{C.~Turon, K.~S.~O'Flaherty, \& M.~A.~C.~Perryman}",
+  month =        jan,
+  pages =        {67-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576...67D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005ESASP.576..207K,
+  author =       {{Klioner}, S.~A.},
+  title =        "{Relativistic Formulation and Reference Frame}",
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {207-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576..207K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005ESASP.576..281C,
+  author =       {{Crosta}, M.~T. and {Mignard}, F.},
+  title =        "{GAREX: a Relativity Experiment with Gaia}",
+  keywords =     {Gaia, Science, General Relativity (GR), Solar
+                  System},
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {281-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576..281C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2005ESASP.576..305K,
+  author =       {{Klioner}, S.~A. and {Soffel}, M.~H.},
+  title =        "{Refining the Relativistic Model for Gaia:
+                  Cosmological Effects in the BCRS}",
+  booktitle =    {The Three-Dimensional Universe with Gaia},
+  year =         2005,
+  series =       {ESA Special Publication},
+  volume =       576,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {305-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005ESASP.576..305K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2005MNRAS.358...30E,
+  author =       {{Eyer}, L. and {Blake}, C.},
+  title =        "{Automated classification of variable stars for
+                  All-Sky Automated Survey 1-2 data}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0406333},
+  year =         2005,
+  month =        mar,
+  volume =       358,
+  pages =        {30-38},
+  doi =          {10.1111/j.1365-2966.2005.08651.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005MNRAS.358...30E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2005MNRAS.359.1306W,
+  author =       {{Wilkinson}, M.~I. and {Vallenari}, A. and {Turon},
+                  C. and {Munari}, U. and {Katz}, D. and {Bono},
+                  G. and {Cropper}, M. and {Helmi}, A. and {Robichon},
+                  N. and {Th{\'e}venin}, F. and {Vidrih}, S. and
+                  {Zwitter}, T. and {Arenou}, F. and {Baylac},
+                  M.-O. and {Bertelli}, G. and {Bijaoui}, A. and
+                  {Boschi}, F. and {Castelli}, F. and {Crifo}, F. and
+                  {David}, M. and {Gomboc}, A. and {G{\'o}mez}, A. and
+                  {Haywood}, M. and {Jauregi}, U. and {de Laverny},
+                  P. and {Lebreton}, Y. and {Marrese}, P. and {Marsh},
+                  T. and {Mignot}, S. and {Morin}, D. and {Pasetto},
+                  S. and {Perryman}, M. and {Pr{\v s}a}, A. and
+                  {Recio-Blanco}, A. and {Royer}, F. and {Sellier},
+                  A. and {Siviero}, A. and {Sordo}, R. and {Soubiran},
+                  C. and {Tomasella}, L. and {Viala}, Y.},
+  title =        "{Spectroscopic survey of the Galaxy with Gaia-
+                  II. The expected science yield from the Radial
+                  Velocity Spectrometer}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0506083},
+  year =         2005,
+  month =        jun,
+  volume =       359,
+  pages =        {1306-1335},
+  doi =          {10.1111/j.1365-2966.2005.09012.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005MNRAS.359.1306W&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2005MNRAS.361.1136E,
+  author =       {{Eyer}, L. and {Mignard}, F.},
+  title =        "{Rate of correct detection of periodic signal with
+                  the Gaia satellite}",
+  journal =      {\mnras},
+  year =         2005,
+  month =        aug,
+  volume =       361,
+  pages =        {1136-1144},
+  doi =          {10.1111/j.1365-2966.2005.09266.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005MNRAS.361.1136E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2005MmSAI..76..531V,
+  author =       {{Vlemmings}, W.~H.~T. and {Chatterjee}, S. and
+                  {Brisken}, W.~F. and {Lazio}, T.~J.~W. and {Cordes},
+                  J.~M. and {Thorsett}, S.~E. and {Goss}, W.~M. and
+                  {Fomalont}, E.~B. and {Kramer}, M. and {Lyne},
+                  A.~G. and {Seagroves}, S. and {Benson}, J.~M. and
+                  {McKinnon}, M.~M. and {Backer}, D.~C. and {Dewey},
+                  R.},
+  title =        "{Pulsar Astrometry at the Microarcsecond Level .}",
+  journal =      {Memorie della Societa Astronomica Italiana},
+  eprint =       {arXiv:astro-ph/0509025},
+  year =         2005,
+  volume =       76,
+  pages =        {531-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2005MmSAI..76..531V},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2005Natur.435..629S,
+   author = {{Springel}, V. and {White}, S.~D.~M. and {Jenkins}, A. and {Frenk}, C.~S. and
+	{Yoshida}, N. and {Gao}, L. and {Navarro}, J. and {Thacker}, R. and
+	{Croton}, D. and {Helly}, J. and {Peacock}, J.~A. and {Cole}, S. and
+	{Thomas}, P. and {Couchman}, H. and {Evrard}, A. and {Colberg}, J. and
+	{Pearce}, F.},
+    title = "{Simulations of the formation, evolution and clustering of galaxies and quasars}",
+  journal = {\nat},
+   eprint = {astro-ph/0504097},
+     year = 2005,
+    month = jun,
+   volume = 435,
+    pages = {629-636},
+      doi = {10.1038/nature03597},
+   adsurl = {http://adsabs.harvard.edu/abs/2005Natur.435..629S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2005PASP..117.1021S,
+  author =       {{Sozzetti}, A.},
+  title =        "{Astrometric Methods and Instrumentation to Identify
+                  and Characterize Extrasolar Planets: A Review}",
+  journal =      {\pasp},
+  eprint =       {astro-ph/0507115},
+  year =         2005,
+  month =        oct,
+  volume =       117,
+  pages =        {1021-1048},
+  doi =          {10.1086/444487},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005PASP..117.1021S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2005cs........2018N,
+  author =       {{Nieto-Santisteban}, M.~A. and {Szalay}, A.~S. and
+                  {Thakar}, A.~R. and {O'Mullane}, W.~J. and {Gray},
+                  J. and {Annis}, J.},
+  title =        "{When Database Systems Meet the Grid}",
+  journal =      {ArXiv Computer Science e-prints},
+  eprint =       {cs/0502018},
+  year =         2005,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2005cs........2018N},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf....5M,
+  author =       {{Mignard}, F.},
+  title =        "{Overall Science Goals of the Gaia Mission}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {5-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf....5M&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf...97S,
+  author =       {{S}\"{o}derhjelm, S.},
+  title =        "{Census of Binaries the Big Picture}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.},
+  month =        jan,
+  pages =        {97-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib\_query?bibcode=2005tdug.conf...97S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf..251L,
+  author =       {{Lattanzi}, M.~G. and {Casertano}, S. and {Jancart},
+                  S. and {Morbidelli}, R. and {Pourbaix}, D. and
+                  {Pannunzio}, R. and {Sozzetti}, A. and {Spagna}, A.},
+  title =        "{Detection and Characterization of Extra-Solar
+                  Planets with Gaia}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {251-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..251L&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf..293F,
+  author =       {{Fienga}, A. and {Laskar}, J. and {Simon}, J.~L. and
+                  {Manche}, H. and {Gastineau}, M.},
+  title =        "{IMCCE Planetary Ephemerides: Present and Future}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {293-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..293F&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf..377B,
+  author =       {{Brown}, A.~G.~A.},
+  title =        "{Gaia Photometric Data Analysis}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {377-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..377B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf..385W,
+  author =       {{Evans}, N.~W. and {Belokurov}, V.},
+  title =        "{A {P}rototype for {S}cience {A}lerts}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {385-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..385W&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf..393B,
+  author =       {{Bailer-Jones}, C.~A.~L.},
+  title =        "{Object Classification and the Determination of
+                  Stellar Parameters}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {393-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..393B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf..433G,
+  author =       {{Gai}, M. and {Busonero}, D. and {Gardiol}, D. and
+                  {Loreggia}, D.  },
+  title =        "{The Gaia Focal Plane to Sky Mapping: A Sample of
+                  Calibration Issues}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {433-+},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..433G&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf..513E,
+  author =       {{Eyer}, L.},
+  title =        "{Variability Analysis: Detection and
+                  Classification}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {513-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..513E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf..645S,
+  author =       {{Spite}, M.},
+  title =        "{Gaia, the Oldest Stars and the Early Universe}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {645-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..645S&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2005tdug.conf..651W,
+  author =       {{Wilkinson}, M.~I.},
+  title =        "{Dark Matter in the Local Group}",
+  booktitle =    {ESA SP-576: The Three-Dimensional Universe with
+                  Gaia},
+  year =         2005,
+  editor =       {{Turon}, C. and {O'Flaherty}, K.~S. and {Perryman},
+                  M.~A.~C.  },
+  month =        jan,
+  pages =        {651-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2005tdug.conf..651W&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006A&A...449..827B,
+  author =       {{Busonero}, D. and {Gai}, M. and {Gardiol}, D. and
+                  {Lattanzi}, M.~G. and {Loreggia}, D.},
+  title =        "{Chromaticity in all-reflective telescopes for
+                  astrometry}",
+  journal =      {\aap},
+  eprint =       {astro-ph/0511572},
+  year =         2006,
+  month =        apr,
+  volume =       449,
+  pages =        {827-836},
+  doi =          {10.1051/0004-6361:20054180},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006A\%26A...449..827B&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006A&A...457..841I,
+   author = {{Ilbert}, O. and {Arnouts}, S. and {McCracken}, H.~J. and {Bolzonella}, M. and
+	{Bertin}, E. and {Le F{\`e}vre}, O. and {Mellier}, Y. and {Zamorani}, G. and
+	{Pell{\`o}}, R. and {Iovino}, A. and {Tresse}, L. and {Le Brun}, V. and
+	{Bottini}, D. and {Garilli}, B. and {Maccagni}, D. and {Picat}, J.~P. and
+	{Scaramella}, R. and {Scodeggio}, M. and {Vettolani}, G. and
+	{Zanichelli}, A. and {Adami}, C. and {Bardelli}, S. and {Cappi}, A. and
+	{Charlot}, S. and {Ciliegi}, P. and {Contini}, T. and {Cucciati}, O. and
+	{Foucaud}, S. and {Franzetti}, P. and {Gavignaud}, I. and {Guzzo}, L. and
+	{Marano}, B. and {Marinoni}, C. and {Mazure}, A. and {Meneux}, B. and
+	{Merighi}, R. and {Paltani}, S. and {Pollo}, A. and {Pozzetti}, L. and
+	{Radovich}, M. and {Zucca}, E. and {Bondi}, M. and {Bongiorno}, A. and
+	{Busarello}, G. and {de La Torre}, S. and {Gregorini}, L. and
+	{Lamareille}, F. and {Mathez}, G. and {Merluzzi}, P. and {Ripepi}, V. and
+	{Rizzo}, D. and {Vergani}, D.},
+    title = "{Accurate photometric redshifts for the CFHT legacy survey calibrated using the VIMOS VLT deep survey}",
+  journal = {\aap},
+   eprint = {astro-ph/0603217},
+ keywords = {galaxies: distances and redshifts, galaxies: photometry, methods: data analysis},
+     year = 2006,
+    month = oct,
+   volume = 457,
+    pages = {841-856},
+      doi = {10.1051/0004-6361:20065138},
+   adsurl = {http://adsabs.harvard.edu/abs/2006A\%26A...457..841I},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2006AJ....131.1163S,
+  author =       {Skrutskie, M. F. and Cutri, R. M. and Stiening,
+                  R. and Weinberg, M. D. and Schneider, S. and
+                  Carpenter, J. M. and Beichman, C. and Capps, R. and
+                  Chester, T. and Elias, J. and Huchra, J. and
+                  Liebert, J. and Lonsdale, C. and Monet, D. G. and
+                  Price, S. and Seitzer, P. and Jarrett, T. and
+                  Kirkpatrick, J. D. and Gizis, J. E. and Howard,
+                  E. and Evans, T. and Fowler, J. and Fullmer, L. and
+                  Hurt, R. and Light, R. and Kopan, E. L. and Marsh,
+                  K. A. and McCallon, H. L. and Tam, R. and Van Dyk,
+                  S. and Wheelock, S.},
+  title =        "{The Two Micron All Sky Survey (2MASS)}",
+  journal =      {The Astronomical Journal},
+  keywords =     {catalogs; infrared: general; surveys},
+  year =         2006,
+  month =        feb,
+  volume =       131,
+  number =       2,
+  doi =          {10.1086/498708},
+  adsurl =       {http://adsabs.harvard.edu/abs/2006AJ....131.1163S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2006ASPC..349...15E,
+  author =       {{Eyer}, L.},
+  title =        "{Astronomical Databases, Space Photometry and Time
+                  Series Analysis: Open Questions}",
+  booktitle =    {Astronomical Society of the Pacific Conference
+                  Series},
+  year =         2006,
+  editor =       {{Sterken}, C. and {Aerts}, C.},
+  month =        apr,
+  pages =        {15-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2006ASPC..349...15E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006ApJ...653.1552D,
+  author =       {{de Felice}, F. and {Vecchiato}, A. and {Crosta},
+                  M.~T. and {Lattanzi}, M.~G. and {Bucciarelli}, B.},
+  title =        "{A general relativistic model for the light
+                  propagation in the gravitational field of the Solar
+                  System: the dynamical case}",
+  journal =      {\apj},
+  year =         2006,
+  volume =       653,
+  pages =        1552,
+  doi =          {10.1051/0004-6361:20042372},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006ApJ...653.1552D&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006CQGra..23.4853C,
+  author =       {{Crosta}, M.~T. and {Mignard}, F.},
+  title =        "{Microarcsecond light bending by Jupiter}",
+  journal =      {Classical and Quantum Gravity},
+  eprint =       {astro-ph/0512359},
+  year =         2006,
+  month =        aug,
+  volume =       23,
+  pages =        {4853-4871},
+  doi =          {10.1088/0264-9381/23/15/006},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006CQGra..23.4853C&db_key=PHY},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006CQGra..23.5467D,
+  author =       {{de Felice}, F. and {Preti}, G.},
+  title =        "{Ray tracing in relativistic astrometry: stellar
+                  positions, stellar motion and error budget}",
+  journal =      {Classical and Quantum Gravity},
+  year =         2006,
+  month =        sep,
+  volume =       23,
+  pages =        {5467-5476},
+  doi =          {10.1088/0264-9381/23/18/001},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006CQGra..23.5467D&db_key=PHY},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006IAUJD..13E..32K,
+  author =       {{Kobayashi}, Y. and {Gouda}, G. and {Tsujimoto},
+                  T. and {Yano}, T. and {Suganuma}, M. and {Yamauchi},
+                  M. and {Takato}, N. and {Miyazaki}, S. and {Yamada},
+                  Y. and {Sako}, N. and {Nakasuka}, S.},
+  title =        "{A very small astrometry satellite mission:
+                  Nano-JASMINE}",
+  journal =      {Exploiting Large Surveys for Galactic Astronomy,
+                  26th meeting of the IAU, Joint Discussion 13, 22-23
+                  August 2006, Prague, Czech Republic, JD13, \#32},
+  year =         2006,
+  month =        aug,
+  volume =       13,
+  adsurl =       {http://adsabs.harvard.edu/abs/2006IAUJD..13E..32K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2006MNRAS.367..290J,
+  author =       {{Jordi}, C. and {H{\o}g}, E. and {Brown},
+                  A.~G.~A. and {Lindegren}, L. and {Bailer-Jones},
+                  C.~A.~L. and {Carrasco}, J.~M. and {Knude}, J. and
+                  {Strai{\v z}ys}, V. and {de Bruijne}, J.~H.~J. and
+                  {Claeskens}, J.-F. and {Drimmel}, R. and {Figueras},
+                  F. and {Grenon}, M. and {Kolka}, I. and {Perryman},
+                  M.~A.~C. and {Tautvai{\v s}ien{\.e}}, G. and
+                  {Vansevi{\v c}ius}, V. and {Willemsen}, P.~G. and
+                  {Brid{\v z}ius}, A. and {Evans}, D.~W. and
+                  {Fabricius}, C. and {Fiorucci}, M. and {Heiter},
+                  U. and {Kaempf}, T.~A. and {Kazlauskas}, A. and
+                  {Ku{\v c}inskas}, A. and {Malyuto}, V. and {Munari},
+                  U. and {Reyl{\'e}}, C. and {Torra}, J. and
+                  {Vallenari}, A. and {Zdanavi{\v c}ius}, K. and
+                  {Korakitis}, R. and {Malkov}, O. and {Smette}, A.},
+  title =        "{The design and performance of the Gaia photometric
+                  system}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0512038},
+  year =         2006,
+  month =        mar,
+  volume =       367,
+  pages =        {290-314},
+  doi =          {10.1111/j.1365-2966.2005.09944.x},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006MNRAS.367..290J&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006MNRAS.367..879C,
+  author =       {{Claeskens}, J.-F. and {Smette}, A. and
+                  {Vandenbulcke}, L. and {Surdej}, J.},
+  title =        "{Identification and redshift determination of
+                  quasi-stellar objects with medium-band photometry:
+                  application to Gaia}",
+  journal =      {\mnras},
+  year =         2006,
+  month =        apr,
+  volume =       367,
+  pages =        {879-904},
+  doi =          {10.1111/j.1365-2966.2006.10024.x},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006MNRAS.367..879C&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006MNRAS.369..677P,
+  author =       {{Protopapas}, P. and {Giammarco}, J.~M. and
+                  {Faccioli}, L. and {Struble}, M.~F. and {Dave},
+                  R. and {Alcock}, C.},
+  title =        "{Finding outlier light curves in catalogues of
+                  periodic variable stars}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0505495},
+  year =         2006,
+  month =        jun,
+  volume =       369,
+  pages =        {677-696},
+  doi =          {10.1111/j.1365-2966.2006.10327.x},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2006MNRAS.369..677P&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006MNRAS.370..141R,
+  author =       {{Recio-Blanco}, A. and {Bijaoui}, A. and {de
+                  Laverny}, P.},
+  title =        "{Automated derivation of stellar atmospheric
+                  parameters and chemical abundances: the MATISSE
+                  algorithm}",
+  journal =      {\mnras},
+  eprint =       {astro-ph/0604385},
+  year =         2006,
+  month =        jul,
+  volume =       370,
+  pages =        {141-150},
+  doi =          {10.1111/j.1365-2966.2006.10455.x},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/cgi-bin/nph-bib_query?bibcode=2006MNRAS.370..141R&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2006MmSAI..77..549E,
+  author =       {{Eyer}, L.},
+  title =        "{The Gaia mission . Pulsating stars with Gaia}",
+  journal =      {Memorie della Societa Astronomica Italiana},
+  eprint =       {astro-ph/0511460},
+  year =         2006,
+  volume =       77,
+  pages =        {549-+},
+  adsurl =
+                  {http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2006MmSAI..77..549E&db_key=AST},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@INPROCEEDINGS{2006SPIE.6206E..01C,
+  author =       {{Chorier}, P. and {Tribolet}, P. and
+                  {Dest{\'e}fanis}, G.},
+  title =        "{From visible to infrared: a new detector approach}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2006,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       6206,
+  month =        may,
+  eid =          620601,
+  pages =        620601,
+  doi =          {10.1117/12.669128},
+  adsurl =       {http://adsabs.harvard.edu/abs/2006SPIE.6206E..01C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2006astro.ph.11885O,
+  author =       {{O'Mullane}, W. and {Lammers}, U. and
+                  {Bailer-Jones}, C. and {Bastian}, U. and {Brown},
+                  A. and {Drimmel}, R. and {Eyer}, L. and {Huc},
+                  C. and {Jansen}, F. and {Katz}, D. and {Lindegren},
+                  L. and {Pourbaix}, D. and {Luri}, X. and {Mignard},
+                  F. and {Torra}, J. and {van Leeuwen}, F.},
+  title =        "{Gaia Data Processing Architecture}",
+  journal =      {ArXiv Astrophysics e-prints},
+  eprint =       {astro-ph/0611885},
+  year =         2006,
+  month =        nov,
+  adsurl =       {http://adsabs.harvard.edu/abs/2006astro.ph.11885O},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2007A&A...467.1373R,
+  author =       {{Re Fiorentin}, P. and {Bailer-Jones}, C.~A.~L. and
+                  {Lee}, Y.~S. and {Beers}, T.~C. and {Sivarani},
+                  T. and {Wilhelm}, R. and {Allende Prieto}, C. and
+                  {Norris}, J.~E.},
+  title =        "{Estimation of stellar atmospheric parameters from
+                  SDSS/SEGUE spectra}",
+  journal =      {Astronomy and Astrophysics},
+  eprint =       {arXiv:astro-ph/0703309},
+  year =         2007,
+  month =        jun,
+  volume =       467,
+  pages =        {1373-1387},
+  doi =          {10.1051/0004-6361:20077334},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/2007A\%26A...467.1373R},
+  adsnote =      {Provided by the Smithsonian/NASA Astrophysics Data
+                  System}
+}
+
+@ARTICLE{2007AJ....134..973I,
+   author = {{Ivezi{\'c}}, {\v Z}. and {Smith}, J.~A. and {Miknaitis}, G. and
+        {Lin}, H. and {Tucker}, D. and {Lupton}, R.~H. and {Gunn}, J.~E. and
+        {Knapp}, G.~R. and {Strauss}, M.~A. and {Sesar}, B. and {Doi}, M. and
+        {Tanaka}, M. and {Fukugita}, M. and {Holtzman}, J. and {Kent}, S. and
+        {Yanny}, B. and {Schlegel}, D. and {Finkbeiner}, D. and {Padmanabhan}, N. and
+        {Rockosi}, C.~M. and {Juri{\'c}}, M. and {Bond}, N. and {Lee}, B. and
+        {Stoughton}, C. and {Jester}, S. and {Harris}, H. and {Harding}, P. and
+        {Morrison}, H. and {Brinkmann}, J. and {Schneider}, D.~P. and
+        {York}, D.},
+    title = "{Sloan Digital Sky Survey Standard Star Catalog for Stripe 82: The Dawn of Industrial 1\% Optical Photometry}",
+  journal = {\aj},
+   eprint = {astro-ph/0703157},
+ keywords = {catalogs, instrumentation: photometers, methods: data analysis, standards, surveys, techniques: photometric},
+     year = 2007,
+    month = sep,
+   volume = 134,
+    pages = {973-998},
+      doi = {10.1086/519976},
+   adsurl = {http://adsabs.harvard.edu/abs/2007AJ....134..973I},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2007AJ....134.1843A,
+  author =       {{Allende Prieto}, C.},
+  title =        "{Velocities from Cross-Correlation: A Guide for
+                  Self-Improvement}",
+  journal =      {\aj},
+  archivePrefix ="arXiv",
+  eprint =       {0707.2764},
+  keywords =     {methods: statistical, stars: kinematics, techniques:
+                  radial velocities},
+  year =         2007,
+  month =        nov,
+  volume =       134,
+  pages =        {1843-1848},
+  doi =          {10.1086/522051},
+  adsurl =       {http://adsabs.harvard.edu/abs/2007AJ....134.1843A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2007ASPC..376..395K,
+  author = {{Kubica}, J. and {Denneau}, Jr., L. and {Moore}, A. and {Jedicke}, R. and
+        {Connolly}, A.},
+   title = "{Efficient Algorithms for Large-Scale Asteroid Discovery}",
+booktitle = {Astronomical Data Analysis Software and Systems XVI},
+    year = 2007,
+  series = {Astronomical Society of the Pacific Conference Series},
+  volume = 376,
+  editor = {{Shaw}, R.~A. and {Hill}, F. and {Bell}, D.~J.},
+   month = oct,
+   pages = {395},
+  adsurl = {http://adsabs.harvard.edu/abs/2007ASPC..376..395K},
+ adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2007ASPC..376..491V,
+  author =       {{Valentijn}, E.~A. and {McFarland}, J.~P. and
+                  {Snigula}, J. and {Begeman}, K.~G. and {Boxhoorn},
+                  D.~R. and {Rengelink}, R. and {Helmich}, E. and
+                  {Heraudeau}, P. and {Kleijn}, G.~V. and {Vermeij},
+                  R. and {Vriend}, W.-J. and {Tempelaar}, M.~J. and
+                  {Deul}, E. and {Kuijken}, K. and {Capaccioli},
+                  M. and {Silvotti}, R. and {Bender}, R. and {Neeser},
+                  M. and {Saglia}, R. and {Bertin}, E. and {Mellier},
+                  Y.},
+  title =        "{Astro-WISE: Chaining to the Universe}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XVI},
+  year =         2007,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       376,
+  eprint =       {arXiv:astro-ph/0702189},
+  editor =       "{R.~A.~Shaw, F.~Hill, \& D.~J.~Bell}",
+  month =        oct,
+  pages =        491,
+  adsurl =       {http://adsabs.harvard.edu/abs/2007ASPC..376..491V},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2007IAUS..236..341J,
+   author = {{Jedicke}, R. and {Magnier}, E.~A. and {Kaiser}, N. and {Chambers}, K.~C.
+	},
+    title = "{The next decade of Solar System discovery with Pan-STARRS}",
+booktitle = {Near Earth Objects, our Celestial Neighbors: Opportunity and Risk},
+     year = 2007,
+   series = {IAU Symposium},
+   volume = 236,
+   editor = {{Valsecchi}, G.~B. and {Vokrouhlick{\'y}}, D. and {Milani}, A.
+	},
+    month = may,
+    pages = {341-352},
+      doi = {10.1017/S1743921307003419},
+   adsurl = {http://adsabs.harvard.edu/abs/2007IAUS..236..341J},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2007PASA...24..189T,
+   author = {{Tabur}, V.},
+    title = "{Fast Algorithms for Matching CCD Images to a Stellar Catalogue}",
+  journal = {\pasa},
+archivePrefix = "arXiv",
+   eprint = {0710.3618},
+ keywords = {astrometry, methods: data analysis, surveys},
+     year = 2007,
+    month = dec,
+   volume = 24,
+    pages = {189-198},
+      doi = {10.1071/AS07028},
+   adsurl = {http://adsabs.harvard.edu/abs/2007PASA...24..189T},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2007arXiv0712.0249O,
+  author =       {{O'Mullane}, W. and {Hoar}, J. and {Lammers}, U.},
+  title =        "{ECSS in the eXtreme}",
+  journal =      {ArXiv e-prints},
+  eprint =       {0712.0249},
+  year =         2007,
+  month =        dec,
+  volume =       712,
+  adsurl =       {http://adsabs.harvard.edu/abs/2007arXiv0712.0249O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2007cs........1164S,
+  author =       {{Szalay}, A.~S. and {Gray}, J. and {Fekete}, G. and
+                  {Kunszt}, P.~Z. and {Kukol}, P. and {Thakar}, A.},
+  title =        "{Indexing the Sphere with the Hierarchical
+                  Triangular Mesh}",
+  journal =      {eprint arXiv:cs/0701164},
+  eprint =       {arXiv:cs/0701164},
+  keywords =     {Computer Science - Databases, Computer Science -
+                  Data Structures and Algorithms},
+  year =         2007,
+  month =        jan,
+  adsurl =       {http://adsabs.harvard.edu/abs/2007cs........1164S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008A&A...478..951K,
+  author =       {{Klioner}, S.~A.},
+  title =        "{Relativistic scaling of astronomical quantities and
+                  the system of astronomical units}",
+  journal =      {\aap},
+  keywords =     {astrometry, reference systems, relativity, time,
+                  ephemerides, celestial mechanics},
+  year =         2008,
+  month =        feb,
+  volume =       478,
+  pages =        {951-958},
+  doi =          {10.1051/0004-6361:20077786},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008A\%26A...478..951K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008A&A...488..401R,
+  author =       {{R{\"o}ser}, S. and {Schilbach}, E. and {Schwan},
+                  H. and {Kharchenko}, N.~V. and {Piskunov}, A.~E. and
+                  {Scholz}, R.-D.},
+  title =        "{PPM-Extended (PPMX) - a catalogue of positions and
+                  proper motions}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {0806.1009},
+  keywords =     {catalogs, astrometry},
+  year =         2008,
+  month =        sep,
+  volume =       488,
+  pages =        {401-408},
+  doi =          {10.1051/0004-6361:200809775},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008A\%26A...488..401R},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008ApJ...679..301B,
+   author = {{Budav{\'a}ri}, T. and {Szalay}, A.~S.},
+    title = "{Probabilistic Cross-Identification of Astronomical Sources}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {0707.1611},
+ keywords = {astrometry, catalogs, galaxies: statistics, methods: statistical },
+     year = 2008,
+    month = may,
+   volume = 679,
+      eid = {301-309},
+    pages = {301-309},
+      doi = {10.1086/587156},
+   adsurl = {http://adsabs.harvard.edu/abs/2008ApJ...679..301B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008arXiv0805.2366I,
+   author = {{Ivezic}, Z. and others},
+    title = "{LSST: from Science Drivers to Reference Design and Anticipated Data Products}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {0805.2366},
+ keywords = {Astrophysics},
+     year = 2008,
+    month = may,
+   adsurl = {http://adsabs.harvard.edu/abs/2008arXiv0805.2366I},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2008AIPC.1082..331H,
+  author =       {{Hogg}, D.~W. and {Lang}, D.},
+  title =        "{Astronomical imaging: The theory of everything}",
+  keywords =     {astronomical atlases, statistical analysis,
+                  astronomical telescopes},
+  booktitle =    {American Institute of Physics Conference Series},
+  year =         2008,
+  series =       {American Institute of Physics Conference Series},
+  volume =       1082,
+  month =        dec,
+  pages =        {331-338},
+  doi =          {10.1063/1.3059072},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008AIPC.1082..331H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008AJ....136..735L,
+  author =       {{Lasker}, B.M. and {Lattanzi}, M.G. and {McLean},
+                  B.J. and {Bucciarelli}, B. and {Drimmel}, R. and
+                  {Garcia}, Jorge and {Greene}, Gretchen and
+                  {Guglielmetti}, Fabrizia and {Hanley}, Christopher
+                  and {Hawkins}, George and {Laidler}, Victoria G. and
+                  {Loomis}, Charles and {Meakes}, Michael and
+                  {Mignani}, Roberto and {Morbidelli}, Roberto and
+                  {Morrison}, Jane and {Pannunzio}, Renato and
+                  {Rosenberg}, Amy and {Sarasso}, Maria and {Smart},
+                  Richard L. and {Spagna}, Alessandro and {Sturch},
+                  Conrad R. and {Volpicelli}, Antonio and {White},
+                  Richard L. and {Wolfe}, David and {Zacchei}, Andrea},
+  title =        "{THE SECOND-GENERATION GUIDE STAR CATALOG:
+                  DESCRIPTION AND PROPERTIES}",
+  journal =      {The Astronomical Journal},
+  keywords =     {astrometry; astronomical data bases: miscellaneous;
+                  catalogs; surveys; techniques: image processing;
+                  techniques: photometric},
+  year =         2008,
+  month =        aug,
+  volume =       136,
+  number =       2,
+  doi =          {10.1088/0004-6256/136/2/735},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008AJ....136..735L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2008ASPC..394...83B,
+   author = {{Berriman}, G.~B. and {Good}, J.~C. and {Laity}, A.~C. and {Kong}, M.
+        },
+    title = "{The Montage Image Mosaic Service: Custom Image Mosaics On-Demand}",
+booktitle = {Astronomical Data Analysis Software and Systems XVII},
+     year = 2008,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 394,
+   editor = {{Argyle}, R.~W. and {Bunclark}, P.~S. and {Lewis}, J.~R.},
+    month = aug,
+    pages = {83},
+   adsurl = {http://adsabs.harvard.edu/abs/2008ASPC..394...83B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2008ASPC..394..487N,
+   author = {{Nicastro}, L. and {Calderone}, G.},
+    title = "{Indexing Astronomical Database Tables using HTM and HEALPix}",
+booktitle = {Astronomical Data Analysis Software and Systems XVII},
+     year = 2008,
+   series = {Astronomical Society of the Pacific Conference Series},
+   volume = 394,
+archivePrefix = "arXiv",
+   eprint = {0711.4964},
+   editor = {{Argyle}, R.~W. and {Bunclark}, P.~S. and {Lewis}, J.~R.},
+    month = aug,
+    pages = {487},
+   adsurl = {http://adsabs.harvard.edu/abs/2008ASPC..394..487N},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008CSE....10....9T,
+  author =       {{Thakar}, A.~R.},
+  title =        "{The Sloan Digital Sky Survey: Drinking from the
+                  Fire Hose}",
+  journal =      {Computing in Science and Engineering},
+  year =         2008,
+  month =        jan,
+  volume =       10,
+  pages =        {9-12},
+  doi =          {10.1109/MCSE.2008.17},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008CSE....10....9T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008CSE....10...30T,
+  author =       {{Thakar}, A.~R. and {Szalay}, A. and {Fekete},
+                  G. and {Gray}, J.  },
+  title =        "{The Catalog Archive Server Database Management
+                  System}",
+  journal =      {Computing in Science and Engineering},
+  year =         2008,
+  month =        jan,
+  volume =       10,
+  pages =        {30-37},
+  doi =          {10.1109/MCSE.2008.15},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008CSE....10...30T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2008ExA....22..143P,
+  author =       {{Perryman}, M. and {de Bruijne}, J. and {Lammers},
+                  U.},
+  title =        "{A parameter database for large scientific projects:
+                  application to the Gaia space astrometry mission}",
+  journal =      {Experimental Astronomy},
+  year =         2008,
+  month =        oct,
+  volume =       22,
+  pages =        {143-150},
+  doi =          {10.1007/s10686-008-9116-7},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008ExA....22..143P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2008SPIE.7021E..0HB,
+  author =       {{Beletic}, J.~W. and {Blank}, R. and {Gulbransen},
+                  D. and {Lee}, D. and {Loose}, M. and {Piquette},
+                  E.~C. and {Sprafke}, T. and {Tennant}, W.~E. and
+                  {Zandian}, M. and {Zino}, J.},
+  title =        "{Teledyne Imaging Sensors: infrared imaging
+                  technologies for astronomy and civil space}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2008,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7021,
+  month =        jul,
+  eid =          {70210H},
+  pages =        {70210H},
+  doi =          {10.1117/12.790382},
+  adsurl =       {http://adsabs.harvard.edu/abs/2008SPIE.7021E..0HB},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2009A&A...496..577Z,
+   author = {{Zechmeister}, M. and {K{\"u}rster}, M.},
+    title = "{The generalised Lomb-Scargle periodogram. A new formalism for the floating-mean and Keplerian periodograms}",
+  journal = {\aap},
+archivePrefix = "arXiv",
+   eprint = {0901.2573},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: data analysis, methods: analytical, methods: statistical, techniques: radial velocities},
+     year = 2009,
+    month = mar,
+   volume = 496,
+    pages = {577-584},
+      doi = {10.1051/0004-6361:200811296},
+   adsurl = {http://adsabs.harvard.edu/abs/2009A\%26A...496..577Z},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2009arXiv0912.0201L,
+   author = {{LSST Science Collaboration}},
+    title = "{LSST Science Book, Version 2.0}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {0912.0201},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Extragalactic Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Galaxy Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2009,
+    month = dec,
+   adsurl = {http://adsabs.harvard.edu/abs/2009arXiv0912.0201L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009ASPC..411...55L,
+  author =       {{Lammers}, U. and {Lindegren}, L. and {O'Mullane},
+                  W. and {Hobbs}, D.  },
+  title =        "{To Boldly Go Where No Man has Gone Before: Seeking
+                  Gaia's Astrometric Solution with AGIS}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  XVIII},
+  year =         2009,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       411,
+  editor =       "{D.~A.~Bohlender, D.~Durand, \& P.~Dowler}",
+  month =        sep,
+  pages =        {55-+},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009ASPC..411...55L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009ASPC..411..470O,
+  author =       {{O'Mullane}, W. and {Hern{\'a}ndez}, J. and {Hoar},
+                  J. and {Lammers}, U.  },
+  title =        "{Gaia Data Processing Architecture 2009}",
+  booktitle =    {Astronomical Data Analysis Software and Systems
+                  XVIII},
+  year =         2009,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       411,
+  editor =       "{D.~A.~Bohlender, D.~Durand, \& P.~Dowler}",
+  month =        sep,
+  pages =        470,
+  adsurl =       {http://esoads.eso.org/abs/2009ASPC..411..470O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2009ApJS..182..543A,
+  author =       {{Abazajian}, K.N. and Adelman-McCarthy, Jennifer
+                  K. and Ageros, Marcel A. and Allam, Sahar S. and
+                  Allende Prieto, Carlos and An, Deokkeun and
+                  Anderson, Kurt S. J. and Anderson, Scott F. and
+                  Annis, James and Bahcall, Neta A. and Bailer-Jones,
+                  C. A. L. and Barentine, J. C. and Bassett, Bruce
+                  A. and Becker, Andrew C. and Beers, Timothy C. and
+                  Bell, Eric F. and Belokurov, Vasily and Berlind,
+                  Andreas A. and Berman, Eileen F. and Bernardi,
+                  Mariangela and Bickerton, Steven J. and Bizyaev,
+                  Dmitry and Blakeslee, John P. and Blanton, Michael
+                  R. and Bochanski, John J. and Boroski, William
+                  N. and Brewington, Howard J. and Brinchmann, Jarle
+                  and Brinkmann, J. and Brunner, Robert J. and
+                  Budavri, Tams and Carey, Larry N. and Carliles,
+                  Samuel and Carr, Michael A. and Castander, Francisco
+                  J. and Cinabro, David and Connolly, A. J. and
+                  Csabai, Istvn and Cunha, Carlos E. and Czarapata,
+                  Paul C. and Davenport, James R. A. and de Haas,
+                  Ernst and Dilday, Ben and Doi, Mamoru and
+                  Eisenstein, Daniel J. and Evans, Michael L. and
+                  Evans, N. W. and Fan, Xiaohui and Friedman, Scott
+                  D. and Frieman, Joshua A. and Fukugita, Masataka and
+                  Gnsicke, Boris T. and Gates, Evalyn and Gillespie,
+                  Bruce and Gilmore, G. and Gonzalez, Belinda and
+                  Gonzalez, Carlos F. and Grebel, Eva K. and Gunn,
+                  James E. and Gyry, Zsuzsanna and Hall, Patrick
+                  B. and Harding, Paul and Harris, Frederick H. and
+                  Harvanek, Michael and Hawley, Suzanne L. and Hayes,
+                  Jeffrey J. E. and Heckman, Timothy M. and Hendry,
+                  John S. and Hennessy, Gregory S. and Hindsley,
+                  Robert B. and Hoblitt, J. and Hogan, Craig J. and
+                  Hogg, David W. and Holtzman, Jon A. and Hyde, Joseph
+                  B. and Ichikawa, Shin-ichi and Ichikawa, Takashi and
+                  Im, Myungshin and Ivezic, Zeljko and Jester,
+                  Sebastian and Jiang, Linhua and Johnson, Jennifer
+                  A. and Jorgensen, Anders M. and Juric, Mario and
+                  Kent, Stephen M. and Kessler, R. and Kleinman,
+                  S. J. and Knapp, G. R. and Konishi, Kohki and Kron,
+                  Richard G. and Krzesinski, Jurek and Kuropatkin,
+                  Nikolay and Lampeitl, Hubert and Lebedeva, Svetlana
+                  and Lee, Myung Gyoon and Lee, Young Sun and French
+                  Leger, R. and Lpine, Sbastien and Li, Nolan and
+                  Lima, Marcos and Lin, Huan and Long, Daniel C. and
+                  Loomis, Craig P. and Loveday, Jon and Lupton, Robert
+                  H. and Magnier, Eugene and Malanushenko, Olena and
+                  Malanushenko, Viktor and Mandelbaum, Rachel and
+                  Margon, Bruce and Marriner, John P. and
+                  Martnez-Delgado, David and Matsubara, Takahiko and
+                  McGehee, Peregrine M. and McKay, Timothy A. and
+                  Meiksin, Avery and Morrison, Heather L. and
+                  Mullally, Fergal and Munn, Jeffrey A. and Murphy,
+                  Tara and Nash, Thomas and Nebot, Ada and Neilsen,
+                  Eric H., Jr. and Newberg, Heidi Jo and Newman, Peter
+                  R. and Nichol, Robert C. and Nicinski, Tom and
+                  Nieto-Santisteban, Maria and Nitta, Atsuko and
+                  Okamura, Sadanori and Oravetz, Daniel J. and
+                  Ostriker, Jeremiah P. and Owen, Russell and
+                  Padmanabhan, Nikhil and Pan, Kaike and Park,
+                  Changbom and Pauls, George and Peoples, John,
+                  Jr. and Percival, Will J. and Pier, Jeffrey R. and
+                  Pope, Adrian C. and Pourbaix, Dimitri and Price,
+                  Paul A. and Purger, Norbert and Quinn, Thomas and
+                  Raddick, M. Jordan and Re Fiorentin, Paola and
+                  Richards, Gordon T. and Richmond, Michael W. and
+                  Riess, Adam G. and Rix, Hans-Walter and Rockosi,
+                  Constance M. and Sako, Masao and Schlegel, David
+                  J. and Schneider, Donald P. and Scholz, Ralf-Dieter
+                  and Schreiber, Matthias R. and Schwope, Axel D. and
+                  Seljak, Uro and Sesar, Branimir and Sheldon, Erin
+                  and Shimasaku, Kazu and Sibley, Valena C. and
+                  Simmons, A. E. and Sivarani, Thirupathi and Allyn
+                  Smith, J. and Smith, Martin C. and Smolcic, Vernesa
+                  and Snedden, Stephanie A. and Stebbins, Albert and
+                  Steinmetz, Matthias and Stoughton, Chris and
+                  Strauss, Michael A. and SubbaRao, Mark and Suto,
+                  Yasushi and Szalay, Alexander S. and Szapudi, Istvn
+                  and Szkody, Paula and Tanaka, Masayuki and Tegmark,
+                  Max and Teodoro, Luis F. A. and Thakar, Aniruddha
+                  R. and Tremonti, Christy A. and Tucker, Douglas
+                  L. and Uomoto, Alan and Vanden Berk, Daniel E. and
+                  Vandenberg, Jan and Vidrih, S. and Vogeley, Michael
+                  S. and Voges, Wolfgang and Vogt, Nicole P. and
+                  Wadadekar, Yogesh and Watters, Shannon and Weinberg,
+                  David H. and West, Andrew A. and White, Simon
+                  D. M. and Wilhite, Brian C. and Wonders, Alainna
+                  C. and Yanny, Brian and Yocum, D. R. and York,
+                  Donald G. and Zehavi, Idit and Zibetti, Stefano and
+                  Zucker, Daniel B.},
+  title =        "{THE SEVENTH DATA RELEASE OF THE SLOAN DIGITAL SKY
+                  SURVEY}",
+  journal =      {The Astrophysical Journal Supplement Series},
+  keywords =     {atlases; catalogs; surveys},
+  year =         2009,
+  month =        jun,
+  volume =       182,
+  number =       2,
+  doi =          {10.1088/0067-0049/182/2/543},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009ApJS..182..543A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009SPIE.7439E..14V,
+  author =       {{Vosteen}, L.~L.~A. and {Draaisma}, F. and {van
+                  Werkhoven}, W.~P. and {van Riel}, L.~J.~M. and
+                  {Mol}, M.~H. and {den Ouden}, G.},
+  title =        "{Wavefront sensor for the ESA-GAIA mission}",
+  booktitle =    {Astronomical and Space Optical Systems},
+  year =         2009,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7439,
+  month =        aug,
+  eid =          743914,
+  pages =        743914,
+  doi =          {10.1117/12.825240},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009SPIE.7439E..14V},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2009SPIE.7439E..29V,
+  author =       {{Vosteen}, L.~L.~A. and {Draaisma}, F. and {van
+                  Werkhoven}, W.~P. and {van Riel}, L.~J.~M. and
+                  {Mol}, M.~H. and {den Ouden}, G.},
+  title =        "{Wavefront sensor for the ESA-GAIA mission}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2009,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7439,
+  month =        aug,
+  doi =          {10.1117/12.825240},
+  adsurl =       {http://adsabs.harvard.edu/abs/2009SPIE.7439E..29V},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010A&A...516A..77B,
+  author =       {{Bombrun}, A. and {Lindegren}, L. and {Holl}, B. and
+                  {Jordan}, S.  },
+  title =        "{Complexity of the Gaia astrometric least-squares
+                  problem and the (non-)feasibility of a direct
+                  solution method}",
+  journal =      {\aap},
+  keywords =     {methods: data analysis, methods: numerical, space
+                  vehicles: instruments, astrometry, reference
+                  systems},
+  year =         2010,
+  month =        jun,
+  volume =       516,
+  pages =        {A77},
+  doi =          {10.1051/0004-6361/200913503},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A\%26A...516A..77B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010A&A...518A..10V,
+  author =       {{Veron-Cetty}, M.P. and {Veron}, P.},
+  title =        "{A catalogue of quasars and active nuclei: 13th
+                  edition}",
+  journal =      {Astronomy and Astrophysics},
+  keywords =     {quasars: general, galaxies: Seyfert, BL Lacertae
+                  objects: general},
+  year =         2010,
+  month =        jul,
+  volume =       518,
+  doi =          {10.1051/0004-6361/201014188},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A&A...518A..10V},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010A&A...523A..48J,
+  author =       {{Jordi}, C. and {Gebran}, M. and {Carrasco},
+                  J.~M. and {de Bruijne}, J.  and {Voss}, H. and
+                  {Fabricius}, C. and {Knude}, J. and {Vallenari},
+                  A. and {Kohley}, R. and {Mora}, A.},
+  title =        "{Gaia broad band photometry}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1008.0815},
+  primaryClass = "astro-ph.IM",
+  keywords =     {instrumentation: photometers, techniques:
+                  photometric, Galaxy: general, dust, extinction,
+                  stars: evolution},
+  year =         2010,
+  month =        nov,
+  volume =       523,
+  eid =          {A48},
+  pages =        {A48},
+  doi =          {10.1051/0004-6361/201015441},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010A\%26A...523A..48J},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010A&A...523A..31H,
+   author = {{Hildebrandt}, H. and {Arnouts}, S. and {Capak}, P. and {Moustakas}, L.~A. and
+	{Wolf}, C. and {Abdalla}, F.~B. and {Assef}, R.~J. and {Banerji}, M. and
+	{Ben{\'{\i}}tez}, N. and {Brammer}, G.~B. and {Budav{\'a}ri}, T. and
+	{Carliles}, S. and {Coe}, D. and {Dahlen}, T. and {Feldmann}, R. and
+	{Gerdes}, D. and {Gillis}, B. and {Ilbert}, O. and {Kotulla}, R. and
+	{Lahav}, O. and {Li}, I.~H. and {Miralles}, J.-M. and {Purger}, N. and
+	{Schmidt}, S. and {Singal}, J.},
+    title = "{PHAT: PHoto-z Accuracy Testing}",
+  journal = {\aap},
+archivePrefix = "arXiv",
+   eprint = {1008.0658},
+ keywords = {techniques: photometric, galaxies: distances and redshifts, galaxies: photometry, cosmology: observations, methods: data analysis},
+     year = 2010,
+    month = nov,
+   volume = 523,
+      eid = {A31},
+    pages = {A31},
+      doi = {10.1051/0004-6361/201014885},
+   adsurl = {http://adsabs.harvard.edu/abs/2010A\%26A...523A..31H},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010AAS...21641512W,
+  author =       {Wood-Vasey, W. Michael and Rest, A. and Smartt,
+                  S. and Huber, M. and Narayan, G. and Price, P. and
+                  Valenti, S. and Smith, K. and Botticella, M. and
+                  Foley, R. J. and Rodney, S. and Young, D. and
+                  Gezari, S. and Chornock, R. and Challis, P. and
+                  Tonry, J. and Chornock, R. and Stubbs, C. and
+                  Welling, J. and Riess, A. and Berger, E. and
+                  Soderberg, A. M. and Sand, D. J. and Kirshner,
+                  R. P. and Builders, PS1},
+  title =        "{The Pan-STARRS 1 Survey Transient Identification
+                  System}",
+  booktitle =    {Bulletin of the American Astronomical Society},
+  year =         2010,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       42,
+  month =        may,
+  adsurl =       {http://adsabs.harvard.edu/abs/2010AAS...21641512W},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010ApJ...708..717S,
+   author = {{Sesar}, B. and {Ivezi{\'c}}, {\v Z}. and {Grammer}, S.~H. and
+        {Morgan}, D.~P. and {Becker}, A.~C. and {Juri{\'c}}, M. and
+        {De Lee}, N. and {Annis}, J. and {Beers}, T.~C. and {Fan}, X. and
+        {Lupton}, R.~H. and {Gunn}, J.~E. and {Knapp}, G.~R. and {Jiang}, L. and
+        {Jester}, S. and {Johnston}, D.~E. and {Lampeitl}, H.},
+    title = "{Light Curve Templates and Galactic Distribution of RR Lyrae Stars from Sloan Digital Sky Survey Stripe 82}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {0910.4611},
+ keywords = {Galaxy: halo, Galaxy: stellar content, Galaxy: structure, methods: data analysis, stars: horizontal-branch, stars: statistics, stars: variables: other},
+     year = 2010,
+    month = jan,
+   volume = 708,
+    pages = {717-741},
+      doi = {10.1088/0004-637X/708/1/717},
+   adsurl = {http://adsabs.harvard.edu/abs/2010ApJ...708..717S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010ApJ...719...59K,
+  author =       {{Kerekes}, G. and {Budav{'a}ri}, T. and {Csabai}, I.
+                  and {Connolly}, A.~J. and {Szalay}, A.~S.},
+  title =        "{Cross Identification of Stars with Unknown Proper Motions}",
+  journal =      {\apj},
+  archivePrefix = "arXiv",
+  eprint =       {1006.2096},
+  keywords =     {astrometry, catalogs, methods: statistical, stars: statistics},
+  year =         2010,
+  month =        aug,
+  volume =       719,
+  pages =        {59-66},
+  doi =          {10.1088/0004-637X/719/1/59},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010ApJ...719...59K},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010IAUS..261..320H,
+  author =       {{Holl}, B. and {Hobbs}, D. and {Lindegren}, L.},
+  title =        "{Spatial correlations in the Gaia astrometric
+                  solution}",
+  keywords =     {Astrometry, reference systems, catalogs, methods:
+                  data analysis, methods: statistical, space vehicles},
+  booktitle =    {IAU Symposium},
+  year =         2010,
+  series =       {IAU Symposium},
+  volume =       261,
+  editor =       "{S.~A.~Klioner, P.~K.~Seidelmann, \& M.~H.~Soffel}",
+  month =        jan,
+  pages =        {320-324},
+  doi =          {10.1017/S1743921309990573},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010IAUS..261..320H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010Icar..209..542M,
+   author = {{Muinonen}, K. and {Belskaya}, I.~N. and {Cellino}, A. and {Delb{\`o}}, M. and
+    {Levasseur-Regourd}, A.-C. and {Penttil{\"a}}, A. and {Tedesco}, E.~F.
+    },
+    title = "{A three-parameter magnitude phase function for asteroids}",
+  journal = {\icarus},
+     year = 2010,
+    month = oct,
+   volume = 209,
+    pages = {542-555},
+      doi = {10.1016/j.icarus.2010.04.003},
+   adsurl = {http://adsabs.harvard.edu/abs/2010Icar..209..542M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010ISSIR...9..279L,
+  author =       {{Lindegren}, L.},
+  title =        "{High-accuracy positioning: astrometry}",
+  journal =      {ISSI Scientific Reports Series},
+  year =         2010,
+  volume =       9,
+  pages =        {279-291},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010ISSIR...9..279L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2010MNRAS.403...96B,
+   author = {{Bailer-Jones}, C.~A.~L.},
+    title = "{The ILIUM forward modelling algorithm for multivariate parameter estimation and its application to derive stellar parameters from Gaia spectrophotometry}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {0911.5242},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: data analysis, methods: statistical, techniques: spectroscopic, surveys, stars: fundamental parameters, dust, extinction},
+     year = 2010,
+    month = mar,
+   volume = 403,
+    pages = {96-116},
+      doi = {10.1111/j.1365-2966.2009.16125.x},
+   adsurl = {http://adsabs.harvard.edu/abs/2010MNRAS.403...96B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7731E..35D,
+  author =       {{de Bruijne}, J. and {Kohley}, R. and {Prusti}, T.},
+  title =        "{Gaia: 1,000 million stars with 100 CCD detectors}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2010,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7731,
+  month =        jul,
+  doi =          {10.1117/12.862062},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7731E..35D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7737E..1FJ,
+   author = {{Jones}, R.~L. and {Padmanabhan}, N. and {Ivezic}, Z. and {Axelrod}, T. and
+	{Bartlett}, J. and {Burke}, D. and {Cinabro}, D. and {Cr{\'e}ze}, M. and
+	{Popescu}, B. and {Saha}, A.},
+    title = "{Solving the global photometric self-calibration problem in LSST}",
+booktitle = {Observatory Operations: Strategies, Processes, and Systems III},
+     year = 2010,
+   series = {\procspie},
+   volume = 7737,
+    month = jul,
+      eid = {77371F},
+    pages = {77371F},
+      doi = {10.1117/12.857743},
+   adsurl = {http://cdsads.u-strasbg.fr/abs/2010SPIE.7737E..1FJ},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2010SPIE.7740E..51G,
+  author =       {{Gaudet}, S. and {Hill}, N. and {Armstrong}, P. and
+                  {Ball}, N. and {Burke}, J. and {Chapel}, B. and
+                  {Chapin}, E. and {Damian}, A. and {Dowler}, P. and
+                  {Gable}, I. and {Goliath}, S. and {Ghiurea}, I. and
+                  {Fabbro}, S. and {Gwyn}, S. and {Jenkins}, D. and
+                  {Kavelaars}, J. and {Major}, B. and {Ouellette},
+                  J. and {Paterson}, M. and {Peddle}, M. and
+                  {Penfold-Brown}, D. and {Pritchet}, C. and {Schade},
+                  D. and {Sobie}, R. and {Woods}, D. and {Yeung},
+                  A. and {Zhang}, Y.},
+  title =        "{CANFAR: the Canadian Advanced Network for
+                  Astronomical Research}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2010,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       7740,
+  month =        jul,
+  doi =          {10.1117/12.858026},
+  adsurl =       {http://adsabs.harvard.edu/abs/2010SPIE.7740E..51G},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011A&A...530A..76W,
+  author =       {{Windmark}, F. and {Lindegren}, L. and {Hobbs}, D.},
+  title =        "{Using Galactic Cepheids to verify Gaia parallaxes}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1104.2348},
+  primaryClass = "astro-ph.IM",
+  keywords =     {stars: variables: Cepheids, space vehicles:
+                  instruments, parallaxes},
+  year =         2011,
+  month =        jun,
+  volume =       530,
+  eid =          {A76},
+  pages =        {A76},
+  doi =          {10.1051/0004-6361/201116929},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011A\%26A...530A..76W},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011AAS...21734408S,
+  author =       {{Schmitz}, M. and {Baker}, K. and {Chan}, B. and
+                  {Corwin}, H., Jr. and {Ebert}, R. and {Frayer},
+                  C. and {Helou}, G. and {LaGue}, C. and {Lo}, T. and
+                  {Madore}, B. and {Mazzarella}, J. and {Pevunova},
+                  O. and {Steer}, I. and {Terek}, S.},
+  title =        "{The NASA/IPAC Extragalactic Database (NED):
+                  Enhanced Content and New Functionality}",
+  booktitle =    {Bulletin of the American Astronomical Society},
+  year =         2011,
+  series =       {Bulletin of the American Astronomical Society},
+  volume =       43,
+  month =        jan,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011AAS...21734408S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011AJ....141...93B,
+   author = {{Butler}, N.~R. and {Bloom}, J.~S.},
+    title = "{Optimal Time-series Selection of Quasars}",
+  journal = {\aj},
+archivePrefix = "arXiv",
+   eprint = {1008.3143},
+ keywords = {cosmology: miscellaneous, methods: statistical, quasars: general, stars: variables: gene
+ral},
+     year = 2011,
+    month = mar,
+   volume = 141,
+      eid = {93},
+    pages = {93},
+      doi = {10.1088/0004-6256/141/3/93},
+   adsurl = {http://adsabs.harvard.edu/abs/2011AJ....141...93B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011ApJ...733...10R,
+   author = {{Richards}, J.~W. and {Starr}, D.~L. and {Butler}, N.~R. and
+        {Bloom}, J.~S. and {Brewer}, J.~M. and {Crellin-Quick}, A. and
+        {Higgins}, J. and {Kennedy}, R. and {Rischard}, M.},
+    title = "{On Machine-learned Classification of Variable Stars with Sparse and Noisy Time-series Data}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1101.1959},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: data analysis, methods: statistical, stars: variables: general, techniques: photometric},
+     year = 2011,
+    month = may,
+   volume = 733,
+      eid = {10},
+    pages = {10},
+      doi = {10.1088/0004-637X/733/1/10},
+   adsurl = {http://adsabs.harvard.edu/abs/2011ApJ...733...10R},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011ApJ...734...36A,
+   author = {{Abrahamse}, A. and {Knox}, L. and {Schmidt}, S. and {Thorman}, P. and
+	{Tyson}, J.~A. and {Zhan}, H.},
+    title = "{Characterizing and Propagating Modeling Uncertainties in Photometrically Derived Redshift Distributions}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1011.2239},
+ primaryClass = "astro-ph.CO",
+ keywords = {cosmological parameters, cosmology: observations, galaxies: distances and redshifts, galaxies: photometry, gravitational lensing: weak},
+     year = 2011,
+    month = jun,
+   volume = 734,
+      eid = {36},
+    pages = {36},
+      doi = {10.1088/0004-637X/734/1/36},
+   adsurl = {http://cdsads.u-strasbg.fr/abs/2011ApJ...734...36A},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011ASPC..442..351O,
+  author =       {{O'Mullane}, W. and {Lammers}, U. and {Hernandez},
+                  J.},
+  title =        "{Gaia: Processing to Archive}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  year =         2011,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       442,
+  editor =       "{I.~N.~Evans, A.~Accomazzi, D.~J.~Mink, \&
+                  A.~H.~Rots}",
+  month =        jul,
+  pages =        351,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..351O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011ASPC..442..443C,
+  author =       {{Connolly}, A.~J. and {Smith}, I. and {Krughoff},
+                  K.~S. and {Gibson}, R.},
+  title =        "{Using the Browser for Science: A Collaborative
+                  Toolkit for Astronomy}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XX},
+  year =         2011,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       442,
+  editor =       {{Evans}, I.~N. and {Accomazzi}, A. and {Mink},
+                  D.~J. and {Rots}, A.~H.  },
+  month =        jul,
+  pages =        443,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ASPC..442..443C},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011EAS....45..109L,
+  author =       {{Lindegren}, L. and {Bastian}, U.},
+  title =        "{Basic principles of scanning space astrometry}",
+  booktitle =    {EAS Publications Series},
+  year =         2011,
+  series =       {EAS Publications Series},
+  volume =       45,
+  month =        feb,
+  pages =        {109-114},
+  doi =          {10.1051/eas/1045018},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011EAS....45..109L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2011EAS....45..351H,
+  author =       {{Hogg}, D.~W. and {Lang}, D.},
+  title =        "{Telescopes don't make catalogues!}",
+  booktitle =    {EAS Publications Series},
+  year =         2011,
+  series =       {EAS Publications Series},
+  volume =       45,
+  archivePrefix ="arXiv",
+  eprint =       {1008.0738},
+  primaryClass = "astro-ph.IM",
+  month =        feb,
+  pages =        {351-358},
+  doi =          {10.1051/eas/1045059},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011EAS....45..351H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011ExA....31..157H,
+  author =       {{Harrison}, D.~L.},
+  title =        "{A fast 2D image reconstruction algorithm from 1D
+                  data for the Gaia mission}",
+  journal =      {Experimental Astronomy},
+  archivePrefix ="arXiv",
+  eprint =       {1107.0210},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Methods, Data analysis},
+  year =         2011,
+  month =        oct,
+  volume =       31,
+  pages =        {157-175},
+  doi =          {10.1007/s10686-011-9240-7},
+  adsurl =       {http://cdsads.u-strasbg.fr/abs/2011ExA....31..157H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011ExA....31..215O,
+  author =       {{O'Mullane}, W. and {Lammers}, U. and {Lindegren},
+                  L. and {Hernandez}, J. and {Hobbs}, D.},
+  title =        "{Implementing the Gaia Astrometric Global Iterative
+                  Solution (AGIS) in Java}",
+  journal =      {Experimental Astronomy},
+  archivePrefix ="arXiv",
+  eprint =       {1108.2206},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrometry, Satellite, Algorithms, Implementation,
+                  Data management},
+  year =         2011,
+  month =        oct,
+  volume =       31,
+  pages =        {215-241},
+  doi =          {10.1007/s10686-011-9248-z},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ExA....31..215O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011ExA....31..243O,
+  author =       {{O'Mullane}, W. and {Luri}, X. and {Parsons}, P. and
+                  {Lammers}, U. and {Hoar}, J. and {Hernandez}, J.},
+  title =        "{Using Java for distributed computing in the Gaia
+                  satellite data processing}",
+  journal =      {Experimental Astronomy},
+  archivePrefix ="arXiv",
+  eprint =       {1108.0355},
+  primaryClass = "cs.CE",
+  keywords =     {Distributed computing, Java, Astrometry, Cloud
+                  computing, Mathematics},
+  year =         2011,
+  month =        oct,
+  volume =       31,
+  pages =        {243-258},
+  doi =          {10.1007/s10686-011-9241-6},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011ExA....31..243O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011JPhCS.328a2006S,
+  author =       {{Sordo}, R. and {Vallenari}, A. and {Tantalo},
+                  R. and {Liu}, C. and {Smith}, K. and {Allard},
+                  F. and {Blomme}, R. and {Bouret}, J.-C. and {Brott},
+                  I. and {de Laverny}, P. and {Edvardsson}, B. and
+                  {Fr{\'e}mat}, Y. and {Heber}, U. and {Josselin},
+                  E. and {Kochukhov}, O. and {Korn}, A. and
+                  {Lanzafame}, A. and {Martayan}, C. and {Martins},
+                  F. and {Plez}, B. and {Schweitzer}, A. and
+                  {Th{\'e}venin}, F. and {Zorec}, J.},
+  title =        "{Stellar libraries for Gaia}",
+  journal =      {Journal of Physics Conference Series},
+  year =         2011,
+  month =        dec,
+  volume =       328,
+  number =       1,
+  eid =          012006,
+  pages =        012006,
+  doi =          {10.1088/1742-6596/328/1/012006},
+  adsurl =       {http://esoads.eso.org/abs/2011JPhCS.328a2006S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011MNRAS.414.2215P,
+  author =       {{Prod'homme}, T. and {Brown}, A.~G.~A. and
+                  {Lindegren}, L. and {Short}, A.~D.~T. and {Brown},
+                  S.~W.},
+  title =        "{Electrode level Monte Carlo model of radiation
+                  damage effects on astronomical CCDs}",
+  journal =      {\mnras},
+  archivePrefix ="arXiv",
+  eprint =       {1103.3630},
+  primaryClass = "astro-ph.IM",
+  keywords =     {instrumentation: detectors, methods: analytical,
+                  methods: data analysis, methods: numerical, space
+                  vehicles, astrometry},
+  year =         2011,
+  month =        jul,
+  volume =       414,
+  pages =        {2215-2228},
+  doi =          {10.1111/j.1365-2966.2011.18537.x},
+  adsurl =       {http://adsabs.harvard.edu/abs/2011MNRAS.414.2215P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011PASP..123..596J,
+   author = {{Jee}, M.~J. and {Tyson}, J.~A.},
+    title = "{Toward Precision LSST Weak-Lensing Measurement. I. Impacts of Atmospheric Turbulence and Optical Aberration}",
+  journal = {\pasp},
+archivePrefix = "arXiv",
+   eprint = {1011.1913},
+ primaryClass = "astro-ph.IM",
+     year = 2011,
+    month = may,
+   volume = 123,
+    pages = {596},
+      doi = {10.1086/660137},
+   adsurl = {http://cdsads.u-strasbg.fr/abs/2011PASP..123..596J},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011arXiv1102.5123H,
+  author =       {{Hassan}, A. and {Fluke}, C.~J.},
+  title =        "{Scientific Visualization in Astronomy: Towards the
+                  Petascale Astronomy Era}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1102.5123},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrophysics - Instrumentation and Methods for
+                  Astrophysics, Computer Science - Graphics},
+  year =         2011,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011arXiv1102.5123H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011arXiv1108.0355O,
+  author =       {{O'Mullane}, W. and {Luri}, X. and {Parsons}, P. and
+                  {Lammers}, U. and {Hoar}, J. and {Hernandez}, J.},
+  title =        "{Using Java for distributed computing in the Gaia
+                  satellite data processing}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1108.0355},
+  primaryClass = "cs.CE",
+  keywords =     {Computer Science - Computational Engineering,
+                  Finance, and Science, Astrophysics - Instrumentation
+                  and Methods for Astrophysics, Computer Science -
+                  Mathematical Software},
+  year =         2011,
+  month =        aug,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011arXiv1108.0355O},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011arXiv1110.0497D,
+  author =       {{Dowler}, P. and {Rixon}, G. and {Tody}, D.},
+  title =        "{IVOA Recommendation: Table Access Protocol Version
+                  1.0}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1110.0497},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrophysics - Instrumentation and Methods for
+                  Astrophysics},
+  year =         2011,
+  month =        oct,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011arXiv1110.0497D},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2011arXiv1110.0528T,
+  author =       {{Taylor}, M. and {Boch}, T. and {Fitzpatrick},
+                  M. and {Allan}, A. and {Paioro}, L. and {Taylor},
+                  J. and {Tody}, D.},
+  title =        "{IVOA Recommendation: SAMP - Simple Application
+                  Messaging Protocol Version 1.2}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1110.0528},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrophysics - Instrumentation and Methods for
+                  Astrophysics},
+  year =         2011,
+  month =        oct,
+  adsurl =       {http://adsabs.harvard.edu/abs/2011arXiv1110.0528T},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...538A..78L,
+  author =       {{Lindegren}, L. and {Lammers}, U. and {Hobbs},
+                  D. and {O'Mullane}, W. and {Bastian}, U. and
+                  {Hern{\'a}ndez}, J.},
+  title =        "{The astrometric core solution for the Gaia
+                  mission. Overview of models, algorithms, and
+                  software implementation}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1112.4139},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, methods: data analysis, methods:
+                  numerical, space vehicles: instruments},
+  year =         2012,
+  month =        feb,
+  volume =       538,
+  eid =          {A78},
+  pages =        {A78},
+  doi =          {10.1051/0004-6361/201117905},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A\%26A...538A..78L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...543A..14H,
+  author =       {{Holl}, B. and {Lindegren}, L.},
+  title =        "{Error characterization of the Gaia astrometric
+                  solution. I. Mathematical basis of the covariance
+                  expansion model}",
+  journal =      {\aap},
+  keywords =     {astrometry, catalogs, methods: data analysis,
+                  methods: statistical, space vehicles: instruments},
+  year =         2012,
+  month =        jul,
+  volume =       543,
+  eid =          {A14},
+  pages =        {A14},
+  doi =          {10.1051/0004-6361/201218807},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A\%26A...543A..14H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...543A..15H,
+  author =       {{Holl}, B. and {Lindegren}, L. and {Hobbs}, D.},
+  title =        "{Error characterization of the Gaia astrometric
+                  solution. II. Validating the covariance expansion
+                  model}",
+  journal =      {\aap},
+  keywords =     {astrometry, catalogs, methods: data analysis,
+                  methods: statistical, space vehicles: instruments},
+  year =         2012,
+  month =        jul,
+  volume =       543,
+  eid =          {A15},
+  pages =        {A15},
+  doi =          {10.1051/0004-6361/201218808},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A\%26A...543A..15H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...543A.100R,
+  author =       {{Robin}, A.~C. and {Luri}, X. and {Reyl{\'e}},
+                  C. and {Isasi}, Y. and {Grux}, E. and
+                  {Blanco-Cuaresma}, S. and {Arenou}, F. and
+                  {Babusiaux}, C. and {Belcheva}, M. and {Drimmel},
+                  R. and {Jordi}, C. and {Krone-Martins}, A. and
+                  {Masana}, E. and {Mauduit}, J.~C. and {Mignard},
+                  F. and {Mowlavi}, N. and {Rocca-Volmerange}, B. and
+                  {Sartoretti}, P. and {Slezak}, E. and {Sozzetti},
+                  A.},
+  title =        "{Gaia Universe model snapshot. A statistical
+                  analysis of the expected contents of the Gaia
+                  catalogue}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1202.0132},
+  primaryClass = "astro-ph.GA",
+  keywords =     {methods: data analysis, Galaxy: stellar content,
+                  catalogs, Galaxy: structure, galaxies: statistics,
+                  stars: statistics},
+  year =         2012,
+  month =        jul,
+  volume =       543,
+  eid =          {A100},
+  pages =        {A100},
+  doi =          {10.1051/0004-6361/201118646},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012A\%26A...543A.100R},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012A&A...547A..59M,
+  author =       {{Mignard}, F. and {Klioner}, S.},
+  title =        "{Analysis of astrometric catalogues with vector
+                  spherical harmonics}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1207.0025},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, proper motions, reference systems,
+                  methods: data analysis},
+  year =         2012,
+  month =        nov,
+  volume =       547,
+  eid =          {A59},
+  pages =        {A59},
+  doi =          {10.1051/0004-6361/201219927},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/2012A\%26A...547A..59M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012ASPC..461..549M,
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs},
+                  D. and {Lammers}, U. and {Yamada}, Y.},
+  title =        "{Combining and Comparing Astrometric Data from
+                  Different Epochs: A Case Study with Hipparcos and
+                  Nano-JASMINE}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XXI},
+  year =         2012,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       461,
+  archivePrefix ="arXiv",
+  eprint =       {1201.2849},
+  primaryClass = "astro-ph.IM",
+  editor =       {{Ballester}, P. and {Egret}, D. and {Lorente},
+                  N.~P.~F.},
+  month =        sep,
+  pages =        549,
+  adsurl =       {http://adsabs.harvard.edu/abs/2012ASPC..461..549M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012ASPC..461..585Y,
+  author =       {{Yamada}, Y. and {Hara}, T. and {Yoshioka}, S. and
+                  {Kobayashi}, Y. and {Gouda}, N. and {Miyashita},
+                  H. and {Hatsutori}, Y. and {Lammers}, U. and
+                  {Michalik}, D.},
+  title =        "{Nano-JASMINE Data Analysis and Publication}",
+  booktitle =    {Astronomical Data Analysis Software and Systems XXI},
+  year =         2012,
+  series =       {Astronomical Society of the Pacific Conference
+                  Series},
+  volume =       461,
+  editor =       {{Ballester}, P. and {Egret}, D. and {Lorente},
+                  N.~P.~F.},
+  month =        sep,
+  pages =        585,
+  adsurl =       {http://adsabs.harvard.edu/abs/2012ASPC..461..585Y},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012ExA....34..669R,
+  author =       {{Risquez}, D. and {van Leeuwen}, F. and {Brown},
+                  A.~G.~A.},
+  title =        "{Dynamical attitude model for Gaia}",
+  journal =      {Experimental Astronomy},
+  keywords =     {Gaia, Spacecraft attitude, Astrometry, Simulation},
+  year =         2012,
+  month =        nov,
+  volume =       34,
+  pages =        {669-703},
+  doi =          {10.1007/s10686-012-9310-5},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012ExA....34..669R},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012PASP..124.1175B,
+   author = {{Bloom}, J.~S. and {Richards}, J.~W. and {Nugent}, P.~E. and
+	{Quimby}, R.~M. and {Kasliwal}, M.~M. and {Starr}, D.~L. and
+	{Poznanski}, D. and {Ofek}, E.~O. and {Cenko}, S.~B. and {Butler}, N.~R. and
+	{Kulkarni}, S.~R. and {Gal-Yam}, A. and {Law}, N.},
+    title = "{Automating Discovery and Classification of Transients and Variable Stars in the Synoptic Survey Era}",
+  journal = {\pasp},
+archivePrefix = "arXiv",
+   eprint = {1106.5491},
+ primaryClass = "astro-ph.IM",
+     year = 2012,
+    month = nov,
+   volume = 124,
+    pages = {1175},
+      doi = {10.1086/668468},
+   adsurl = {http://cdsads.u-strasbg.fr/abs/2012PASP..124.1175B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012PASP..124.1347Y,
+   author = {{Yagi}, M.},
+    title = "{Crosstalk Analysis of Suprime-Cam FDCCDs Using Cosmic Rays in Dark Frames}",
+  journal = {\pasp},
+archivePrefix = "arXiv",
+   eprint = {1210.8212},
+ primaryClass = "astro-ph.IM",
+     year = 2012,
+    month = dec,
+   volume = 124,
+    pages = {1347},
+      doi = {10.1086/668891},
+   adsurl = {http://adsabs.harvard.edu/abs/2012PASP..124.1347Y},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@PHDTHESIS{2012PhDT.......175S,
+  author =       {{Sahlmann}, J.},
+  title =        "{Observing exoplanet populations with high-precision
+                  astrometry}",
+  keywords =     {extrasolar planets, astrometry, radial velocities,
+                  interferometry, brown dwarfs, stars: binaries,
+                  stars: low-mass},
+  school =       {Observatoire de Gen{\`e}ve, Universit{\'e} de
+                  Gen{\`e}ve
+                  <EMAIL>Johannes.Sahlmann@unige.ch</EMAIL>},
+  year =         2012,
+  month =        jun,
+  adsurl =       {http://adsabs.harvard.edu/abs/2012PhDT.......175S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8442E..1PK,
+  author =       {{Kohley}, R. and {Gar{\'e}}, P. and {V{\'e}tel},
+                  C. and {Marchais}, D. and {Chassat}, F.},
+  title =        "{Gaia's FPA: sampling the sky in silicon}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2012,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       8442,
+  month =        sep,
+  eid =          {84421P},
+  doi =          {10.1117/12.926144},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8442E..1PK},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8442E..1QM,
+  author =       {{Mora}, A. and {Vosteen}, A.},
+  title =        "{Gaia in-orbit realignment: overview and data
+                  analysis}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2012,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       8442,
+  archivePrefix ="arXiv",
+  eprint =       {1207.2087},
+  primaryClass = "astro-ph.IM",
+  month =        sep,
+  eid =          {84421Q},
+  doi =          {10.1117/12.926313},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8442E..1QM},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8442E..1RG,
+  author =       {{Gielesen}, W. and {de Bruijn}, D. and {van den
+                  Dool}, T. and {Kamphues}, F. and {Meijer}, E. and
+                  {Calvel}, B. and {Laborie}, A. and {Monteiro},
+                  D. and {Coatantiec}, C. and {Touzeau}, S. and
+                  {Erdmann}, M. and {Gare}, P.},
+  title =        "{Gaia basic angle monitoring system}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2012,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       8442,
+  month =        sep,
+  eid =          {84421R},
+  doi =          {10.1117/12.926322},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8442E..1RG},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2012SPIE.8449E..0GC,
+  author =       {{Comoretto}, G. and {Gallegos}, J. and {Els}, S. and
+                  {Gracia}, G. and {Lock}, T. and {Mercier}, E. and
+                  {O'Mullane}, W.},
+  title =        "{The Information Management Tool (IMT) of Gaia DPAC
+                  and its potential as tool for large scale software
+                  development projects}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2012,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       8449,
+  month =        sep,
+  eid =          {84490G},
+  doi =          {10.1117/12.926797},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012SPIE.8449E..0GC},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@BOOK{2012adm..book.....S,
+  author =       {{Sarro}, L.~M. and {Eyer}, L. and {O'Mullane},
+                  W. and {De Ridder}, J.  },
+  title =        "{Astrostatistics and Data Mining}",
+  keywords =     {Physics},
+  booktitle =    {Astrostatistics and Data Mining},
+  year =         2012,
+  doi =          {10.1007/978-1-4614-3323-1},
+  publisher =    {Springer},
+  adsurl =       {http://adsabs.harvard.edu/abs/2012adm..book.....S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012arXiv1202.0132R,
+  author =       {{Robin}, A.~C. and {Luri}, X. and {Reyl{\'e}},
+                  C. and {Isasi}, Y. and {Grux}, E. and
+                  {Blanco-Cuaresma}, S. and {Arenou}, F. and
+                  {Babusiaux}, C. and {Belcheva}, M. and {Drimmel},
+                  R. and {Jordi}, C. and {Krone-Martins}, A. and
+                  {Masana}, E. and {Mauduit}, J.~C. and {Mignard},
+                  F. and {Mowlavi}, N. and {Rocca-Volmerange}, B. and
+                  {Sartoretti}, P. and {Slezak}, E. and {Sozzetti},
+                  A.},
+  title =        "{Gaia Universe Model Snapshot : A statistical
+                  analysis of the expected contents of the Gaia
+                  catalogue}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1202.0132},
+  primaryClass = "astro-ph.GA",
+  keywords =     {Astrophysics - Galaxy Astrophysics, Astrophysics -
+                  Cosmology and Extragalactic Astrophysics,
+                  Astrophysics - Instrumentation and Methods for
+                  Astrophysics, Astrophysics - Solar and Stellar
+                  Astrophysics},
+  year =         2012,
+  month =        feb,
+  adsurl =       {http://adsabs.harvard.edu/abs/2012arXiv1202.0132R},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2012arXiv1210.5007W,
+  author =       {{Wyrzykowski}, L. and {Hodgkin}, S. and
+                  {Blogorodnova}, N. and {Koposov}, S. and {Burgon},
+                  R.},
+  title =        "{Photometric Science Alerts from Gaia}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1210.5007},
+  primaryClass = "astro-ph.IM",
+  keywords =     {Astrophysics - Instrumentation and Methods for
+                  Astrophysics},
+  year =         2012,
+  month =        oct,
+  adsurl =       {http://ads.nao.ac.jp/abs/2012arXiv1210.5007W},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@MISC{2013ascl.soft04011C,
+   author = {{Carrasco Kind}, M. and {Brunner}, R.},
+    title = "{TPZ: Trees for Photo-Z}",
+ keywords = {Software},
+howpublished = {Astrophysics Source Code Library},
+     year = 2013,
+    month = apr,
+archivePrefix = "ascl",
+   eprint = {1304.011},
+   adsurl = {http://adsabs.harvard.edu/abs/2013ascl.soft04011C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013A&A...559A..74B,
+  author =       {{Bailer-Jones}, C.~A.~L. and {Andrae}, R. and
+                  {Arcay}, B. and {Astraatmadja}, T. and
+                  {Bellas-Velidis}, I. and {Berihuete}, A. and
+                  {Bijaoui}, A. and {Carri{\'o}n}, C. and {Dafonte},
+                  C. and {Damerdji}, Y. and {Dapergolas}, A. and {de
+                  Laverny}, P. and {Delchambre}, L. and {Drazinos},
+                  P. and {Drimmel}, R. and {Fr{\'e}mat}, Y. and
+                  {Fustes}, D. and {Garc{\'{\i}}a-Torres}, M. and
+                  {Gu{\'e}d{\'e}}, C. and {Heiter}, U. and {Janotto},
+                  A.-M. and {Karampelas}, A. and {Kim}, D.-W. and
+                  {Knude}, J. and {Kolka}, I. and {Kontizas}, E. and
+                  {Kontizas}, M. and {Korn}, A.~J. and {Lanzafame},
+                  A.~C. and {Lebreton}, Y. and {Lindstr{\o}m}, H. and
+                  {Liu}, C. and {Livanou}, E. and {Lobel}, A. and
+                  {Manteiga}, M. and {Martayan}, C. and {Ordenovic},
+                  C. and {Pichon}, B. and {Recio-Blanco}, A. and
+                  {Rocca-Volmerange}, B. and {Sarro}, L.~M. and
+                  {Smith}, K. and {Sordo}, R. and {Soubiran}, C. and
+                  {Surdej}, J. and {Th{\'e}venin}, F. and
+                  {Tsalmantza}, P. and {Vallenari}, A. and {Zorec},
+                  J.},
+  title =        "{The Gaia astrophysical parameters inference system
+                  (Apsis). Pre-launch description}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1309.2157},
+  primaryClass = "astro-ph.IM",
+  keywords =     {galaxies: fundamental parameters, methods: data
+                  analysis, methods:, statistical, stars: fundamental
+                  parameters, surveys},
+  year =         2013,
+  month =        nov,
+  volume =       559,
+  eid =          {A74},
+  pages =        {A74},
+  doi =          {10.1051/0004-6361/201322344},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/2013A\%26A...559A..74B},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013ApJ...775...93D,
+   author = {{Dahlen}, T. and {Mobasher}, B. and {Faber}, S.~M. and {Ferguson}, H.~C. and
+	{Barro}, G. and {Finkelstein}, S.~L. and {Finlator}, K. and
+	{Fontana}, A. and {Gruetzbauch}, R. and {Johnson}, S. and {Pforr}, J. and
+	{Salvato}, M. and {Wiklind}, T. and {Wuyts}, S. and {Acquaviva}, V. and
+	{Dickinson}, M.~E. and {Guo}, Y. and {Huang}, J. and {Huang}, K.-H. and
+	{Newman}, J.~A. and {Bell}, E.~F. and {Conselice}, C.~J. and
+	{Galametz}, A. and {Gawiser}, E. and {Giavalisco}, M. and {Grogin}, N.~A. and
+	{Hathi}, N. and {Kocevski}, D. and {Koekemoer}, A.~M. and {Koo}, D.~C. and
+	{Lee}, K.-S. and {McGrath}, E.~J. and {Papovich}, C. and {Peth}, M. and
+	{Ryan}, R. and {Somerville}, R. and {Weiner}, B. and {Wilson}, G.
+	},
+    title = "{A Critical Assessment of Photometric Redshift Methods: A CANDELS Investigation}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1308.5353},
+ keywords = {galaxies: distances and redshifts, galaxies: high-redshift, galaxies: photometry, surveys },
+     year = 2013,
+    month = oct,
+   volume = 775,
+      eid = {93},
+    pages = {93},
+      doi = {10.1088/0004-637X/775/2/93},
+   adsurl = {http://adsabs.harvard.edu/abs/2013ApJ...775...93D},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013GWN.....6....4A,
+  author =       {{Amaro-Seoane}, P. and {Aoudia}, S. and {Babak},
+                  S. and {Bin{\'e}truy}, P. and {Berti}, E. and
+                  {Boh{\'e}}, A. and {Caprini}, C. and {Colpi}, M. and
+                  {Cornish}, N.~J. and {Danzmann}, K. and {Dufaux},
+                  J.-F. and {Gair}, J. and {Hinder}, I. and
+                  {Jennrich}, O. and {Jetzer}, P. and {Klein}, A. and
+                  {Lang}, R.~N. and {Lobo}, A. and {Littenberg},
+                  T. and {McWilliams}, S.~T. and {Nelemans}, G. and
+                  {Petiteau}, A. and {Porter}, E.~K. and {Schutz},
+                  B.~F. and {Sesana}, A. and {Stebbins}, R. and
+                  {Sumner}, T. and {Vallisneri}, M. and {Vitale},
+                  S. and {Volonteri}, M. and {Ward}, H. and {Wardell},
+                  B.},
+  title =        "{eLISA: Astrophysics and cosmology in the millihertz
+                  regime}",
+  journal =      {GW Notes, Vol.~6, p.~4-110},
+  archivePrefix ="arXiv",
+  eprint =       {1201.3621},
+  primaryClass = "astro-ph.CO",
+  keywords =     {Astrophysics - Cosmology and Extragalactic
+                  Astrophysics, Astrophysics - Galaxy Astrophysics,
+                  General Relativity and Quantum Cosmology, black
+                  holes, gravitational waves},
+  year =         2013,
+  month =        may,
+  volume =       6,
+  pages =        {4-110},
+  adsurl =       {http://adsabs.harvard.edu/abs/2013GWN.....6....4A},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2013IAUS..289..414M,
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs},
+                  D. and {Lammers}, U. and {Yamada}, Y.},
+  title =        "{Improving distance estimates to nearby bright
+                  stars: Combining astrometric data from Hipparcos,
+                  Nano-JASMINE and Gaia}",
+  keywords =     {astrometry, catalogs, methods: data analysis,
+                  methods: statistical, reference systems,},
+  booktitle =    {IAU Symposium},
+  year =         2013,
+  series =       {IAU Symposium},
+  volume =       289,
+  editor =       {{de Grijs}, R.},
+  month =        feb,
+  pages =        {414-417},
+  doi =          {10.1017/S1743921312021849},
+  adsurl =       {http://adsabs.harvard.edu/abs/2013IAUS..289..414M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013MNRAS.429..556M,
+   author = {{Merson}, A.~I. and {Baugh}, C.~M. and {Helly}, J.~C. and {Gonzalez-Perez}, V. and
+	{Cole}, S. and {Bielby}, R. and {Norberg}, P. and {Frenk}, C.~S. and
+	{Benson}, A.~J. and {Bower}, R.~G. and {Lacey}, C.~G. and {Lagos}, C.~d.~P.
+	},
+    title = "{Lightcone mock catalogues from semi-analytic models of galaxy formation - I. Construction and application to the BzK colour selection}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1206.4049},
+ keywords = {methods: numerical, galaxies: formation, galaxies: statistics, cosmology: large-scale structure of Universe, astronomical data bases: miscellaneous},
+     year = 2013,
+    month = feb,
+   volume = 429,
+    pages = {556-578},
+      doi = {10.1093/mnras/sts355},
+   adsurl = {http://adsabs.harvard.edu/abs/2013MNRAS.429..556M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013MNRAS.430.3155S,
+  author =       {{Seabroke}, G.~M. and {Prod'homme}, T. and {Murray},
+                  N.~J. and {Crowley}, C. and {Hopkinson}, G. and
+                  {Brown}, A.~G.~A. and {Kohley}, R. and {Holland},
+                  A.},
+  title =        "{Digging supplementary buried channels:
+                  investigating the notch architecture within the CCD
+                  pixels on ESA's Gaia satellite}",
+  journal =      {\mnras},
+  archivePrefix ="arXiv",
+  eprint =       {1302.1873},
+  primaryClass = "astro-ph.IM",
+  keywords =     {instrumentation: detectors, methods: laboratory,
+                  methods: numerical, space vehicles: instruments,
+                  astrometry, galaxies: general},
+  year =         2013,
+  month =        apr,
+  volume =       430,
+  pages =        {3155-3170},
+  doi =          {10.1093/mnras/stt121},
+  adsurl =       {http://adsabs.harvard.edu/abs/2013MNRAS.430.3155S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013MNRAS.431.1275B,
+   author = {{Bickerton}, S.~J. and {Lupton}, R.~H.},
+    title = "{An algorithm for precise aperture photometry of critically sampled images}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1302.4764},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: analytical, methods: data analysis, methods: numerical, techniques: image proce
+ssing, techniques: photometric},
+     year = 2013,
+    month = may,
+   volume = 431,
+    pages = {1275-1285},
+      doi = {10.1093/mnras/stt244},
+   adsurl = {http://adsabs.harvard.edu/abs/2013MNRAS.431.1275B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2013MNRAS.432.1483C,
+   author = {{Carrasco Kind}, M. and {Brunner}, R.~J.},
+    title = "{TPZ: photometric redshift PDFs and ancillary information by using prediction trees and random forests}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1303.7269},
+ keywords = {methods: data analysis, methods: statistical, surveys, galaxies: distances and redshift, galaxies: statistics},
+     year = 2013,
+    month = jun,
+   volume = 432,
+    pages = {1483-1501},
+      doi = {10.1093/mnras/stt574},
+   adsurl = {http://adsabs.harvard.edu/abs/2013MNRAS.432.1483C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014A&A...566A.119L,
+  author =       {{Luri}, X. and {Palmer}, M. and {Arenou}, F. and
+                  {Masana}, E. and {de Bruijne}, J. and {Antiche},
+                  E. and {Babusiaux}, C. and {Borrachero}, R. and
+                  {Sartoretti}, P. and {Julbe}, F. and {Isasi}, Y. and
+                  {Martinez}, O. and {Robin}, A.~C. and {Reyl{\'e}},
+                  C. and {Jordi}, C. and {Carrasco}, J.~M.  },
+  title =        "{Overview and stellar statistics of the expected
+                  Gaia Catalogue using the Gaia Object Generator}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1404.5861},
+  primaryClass = "astro-ph.IM",
+  keywords =     {stars: statistics, galaxies: statistics, Galaxy:
+                  stellar content, methods: data analysis, astrometry,
+                  catalogs},
+  year =         2014,
+  month =        jun,
+  volume =       566,
+  eid =          {A119},
+  pages =        {A119},
+  doi =          {10.1051/0004-6361/201423636},
+  adsurl =
+                  {http://cdsads.u-strasbg.fr/abs/2014A\%26A...566A.119L},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014A&A...571A..85M,
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs},
+                  D. and {Lammers}, U.  },
+  title =        "{Joint astrometric solution of HIPPARCOS and Gaia. A
+                  recipe for the Hundred Thousand Proper Motions
+                  project}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1407.4025},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, methods: data analysis, methods:
+                  numerical, space vehicles: instruments, proper
+                  motions, planets and satellites: detection},
+  year =         2014,
+  month =        nov,
+  volume =       571,
+  eid =          {A85},
+  pages =        {A85},
+  doi =          {10.1051/0004-6361/201424606},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014A\%26A...571A..85M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014AJ....147..109S,
+  author =       {{Sick}, J. and {Courteau}, S. and {Cuillandre}, J.-C. and {McDonald}, M.
+                  and {de Jong}, R. and {Tully}, R.~B.},
+  title =        "{Andromeda (M31) Optical and Infrared Disk Survey. I. Insights in
+                   Wide-field Near-IR Surface Photometry}",
+  journal =      {\aj},
+  archivePrefix = "arXiv",
+  eprint =       {1303.6290},
+  primaryClass = "astro-ph.IM",
+  keywords =     {methods: observational, techniques: photometric },
+  year =         2014,
+  month =        may,
+  volume =       147,
+  eid =          {109},
+  pages =        {109},
+  doi =          {10.1088/0004-6256/147/5/109},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014AJ....147..109S},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014ApJS..212...18B,
+   author = {{Brown}, M.~J.~I. and {Moustakas}, J. and {Smith}, J.-D.~T. and
+	{da Cunha}, E. and {Jarrett}, T.~H. and {Imanishi}, M. and {Armus}, L. and
+	{Brandl}, B.~R. and {Peek}, J.~E.~G.},
+    title = "{An Atlas of Galaxy Spectral Energy Distributions from the Ultraviolet to the Mid-infrared}",
+  journal = {\apjs},
+archivePrefix = "arXiv",
+   eprint = {1312.3029},
+ keywords = {atlases, galaxies: general, galaxies: photometry, techniques: spectroscopic},
+     year = 2014,
+    month = jun,
+   volume = 212,
+      eid = {18},
+    pages = {18},
+      doi = {10.1088/0067-0049/212/2/18},
+   adsurl = {http://adsabs.harvard.edu/abs/2014ApJS..212...18B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014EAS....67...15P,
+  author =       {{Prusti}, T.},
+  title =        "{Gaia Mission Status}",
+  booktitle =    {EAS Publications Series},
+  year =         2014,
+  series =       {EAS Publications Series},
+  volume =       67,
+  month =        jul,
+  pages =        {15-21},
+  doi =          {10.1051/eas/1567003},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014EAS....67...15P},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@BOOK{2014sdmm.book.....I,
+   author = {{Ivezi{\'c}}, {\v Z}. and {Connolly}, A.~J. and {VanderPlas}, J.~T. and
+        {Gray}, A.},
+    title = "{Statistics, Data Mining, and Machine Learning in Astronomy}",
+booktitle = {Statistics, Data Mining, and Machine Learning in Astronomy},
+     year = 2014,
+publisher = {Princeton University Press},
+   adsurl = {http://adsabs.harvard.edu/abs/2014sdmm.book.....I},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014MNRAS.439..264G,
+   author = {{Gonzalez-Perez}, V. and {Lacey}, C.~G. and {Baugh}, C.~M. and
+	{Lagos}, C.~D.~P. and {Helly}, J. and {Campbell}, D.~J.~R. and
+	{Mitchell}, P.~D.},
+    title = "{How sensitive are predicted galaxy luminosities to the choice of stellar population synthesis model?}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1309.7057},
+ primaryClass = "astro-ph.CO",
+ keywords = {stars: AGB and post-AGB, galaxies: evolution, galaxies: formation},
+     year = 2014,
+    month = mar,
+   volume = 439,
+    pages = {264-283},
+      doi = {10.1093/mnras/stt2410},
+   adsurl = {http://adsabs.harvard.edu/abs/2014MNRAS.439..264G},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014MNRAS.441.3550C,
+   author = {{Carrasco Kind}, M. and {Brunner}, R.~J.},
+    title = "{Sparse representation of photometric redshift probability density functions: preparing for petascale astronomy}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1404.6442},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: data analysis, methods: statistical, astronomical data bases: miscellaneous, galaxies: distances and redshifts, galaxies: statistics},
+     year = 2014,
+    month = jul,
+   volume = 441,
+    pages = {3550-3561},
+      doi = {10.1093/mnras/stu827},
+   adsurl = {http://adsabs.harvard.edu/abs/2014MNRAS.441.3550C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2014MNRAS.445.1482S,
+   author = {{S{\'a}nchez}, C. and {Carrasco Kind}, M. and {Lin}, H. and
+	{Miquel}, R. and {Abdalla}, F.~B. and {Amara}, A. and {Banerji}, M. and
+	{Bonnett}, C. and {Brunner}, R. and {Capozzi}, D. and {Carnero}, A. and
+	{Castander}, F.~J. and {da Costa}, L.~A.~N. and {Cunha}, C. and
+	{Fausti}, A. and {Gerdes}, D. and {Greisel}, N. and {Gschwend}, J. and
+	{Hartley}, W. and {Jouvel}, S. and {Lahav}, O. and {Lima}, M. and
+	{Maia}, M.~A.~G. and {Mart{\'{\i}}}, P. and {Ogando}, R.~L.~C. and
+	{Ostrovski}, F. and {Pellegrini}, P. and {Rau}, M.~M. and {Sadeh}, I. and
+	{Seitz}, S. and {Sevilla-Noarbe}, I. and {Sypniewski}, A. and
+	{de Vicente}, J. and {Abbot}, T. and {Allam}, S.~S. and {Atlee}, D. and
+	{Bernstein}, G. and {Bernstein}, J.~P. and {Buckley-Geer}, E. and
+	{Burke}, D. and {Childress}, M.~J. and {Davis}, T. and {DePoy}, D.~L. and
+	{Dey}, A. and {Desai}, S. and {Diehl}, H.~T. and {Doel}, P. and
+	{Estrada}, J. and {Evrard}, A. and {Fern{\'a}ndez}, E. and {Finley}, D. and
+	{Flaugher}, B. and {Frieman}, J. and {Gaztanaga}, E. and {Glazebrook}, K. and
+	{Honscheid}, K. and {Kim}, A. and {Kuehn}, K. and {Kuropatkin}, N. and
+	{Lidman}, C. and {Makler}, M. and {Marshall}, J.~L. and {Nichol}, R.~C. and
+	{Roodman}, A. and {S{\'a}nchez}, E. and {Santiago}, B.~X. and
+	{Sako}, M. and {Scalzo}, R. and {Smith}, R.~C. and {Swanson}, M.~E.~C. and
+	{Tarle}, G. and {Thomas}, D. and {Tucker}, D.~L. and {Uddin}, S.~A. and
+	{Vald{\'e}s}, F. and {Walker}, A. and {Yuan}, F. and {Zuntz}, J.
+	},
+    title = "{Photometric redshift analysis in the Dark Energy Survey Science Verification data}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1406.4407},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astronomical data bases: surveys, galaxies: distances and redshifts, galaxies: statistics, large-scale structure of Universe},
+     year = 2014,
+    month = dec,
+   volume = 445,
+    pages = {1482-1506},
+      doi = {10.1093/mnras/stu1836},
+   adsurl = {http://adsabs.harvard.edu/abs/2014MNRAS.445.1482S},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014SPIE.9143E..0XM,
+  author =       {{Mora}, A. and {Biermann}, M. and {Brown},
+                  A.~G.~A. and {Busonero}, D. and {Carminati}, L. and
+                  {Carrasco}, J.~M. and {Chassat}, F. and {Erdmann},
+                  M. and {Gielesen}, W.~L.~M. and {Jordi}, C. and
+                  {Katz}, D. and {Kohley}, R. and {Lindegren}, L. and
+                  {Loeffler}, W. and {Marchal}, O. and {Panuzzo},
+                  P. and {Seabroke}, G. and {Sahlmann}, J. and
+                  {Serpell}, E. and {Serraller}, I. and {van Leeuwen},
+                  F. and {van Reeven}, W. and {van den Dool},
+                  T.~C. and {Vosteen}, L.~L.~A.},
+  title =        "{Gaia on-board metrology: basic angle and best
+                  focus}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2014,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       9143,
+  archivePrefix ="arXiv",
+  eprint =       {1407.3729},
+  primaryClass = "astro-ph.IM",
+  month =        aug,
+  eid =          {91430X},
+  pages =        0,
+  doi =          {10.1117/12.2054602},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014SPIE.9143E..0XM},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014SPIE.9150E..1EG,
+  author =       {{Gill}, R. and {Gracia}, G. and {Lupton}, R.~H. and
+                  {O'Mullane}, W.  },
+  title =        "{Novel technique for tracking manpower and work
+                  packages: a useful tool for the team and
+                  management}",
+  booktitle =    {Modeling, Systems Engineering, and Project
+                  Management for Astronomy VI},
+  year =         2014,
+  series =       {SPIE},
+  volume =       9150,
+  month =        aug,
+  eid =          {91501E},
+  pages =        {91501E},
+  doi =          {10.1117/12.2054745},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014SPIE.9150E..1EG},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2014SPIE.9154E..0MJ,
+  author =       {{Jorden}, P.~R. and {Jordan}, D. and {Jerram},
+                  P.~A. and {Pratlong}, J. and {Swindells}, I.},
+  title =        "{e2v new CCD and CMOS technology developments for
+                  astronomical sensors}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2014,
+  series =       {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  volume =       9154,
+  month =        jul,
+  eid =          {91540M},
+  pages =        {91540M},
+  doi =          {10.1117/12.2069423},
+  adsurl =       {http://adsabs.harvard.edu/abs/2014SPIE.9154E..0MJ},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015A&A...574A.115M,
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs}, D.},
+  title =        "{The Tycho-Gaia astrometric solution . How to get
+                  2.5 million parallaxes with less than one year of
+                  Gaia data}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1412.8770},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, methods: data analysis, methods:
+                  numerical, space vehicles: instruments, parallaxes,
+                  proper motions},
+  year =         2015,
+  month =        feb,
+  volume =       574,
+  eid =          {A115},
+  pages =        {A115},
+  doi =          {10.1051/0004-6361/201425310},
+  adsurl =       {http://adsabs.harvard.edu/abs/2015A\%26A...574A.115M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015A&A...576A..79L,
+   author = {{Le F{\`e}vre}, O. and {Tasca}, L.~A.~M. and {Cassata}, P. and
+	{Garilli}, B. and {Le Brun}, V. and {Maccagni}, D. and {Pentericci}, L. and
+	{Thomas}, R. and {Vanzella}, E. and {Zamorani}, G. and {Zucca}, E. and
+	{Amorin}, R. and {Bardelli}, S. and {Capak}, P. and {Cassar{\`a}}, L. and
+	{Castellano}, M. and {Cimatti}, A. and {Cuby}, J.~G. and {Cucciati}, O. and
+	{de la Torre}, S. and {Durkalec}, A. and {Fontana}, A. and {Giavalisco}, M. and
+	{Grazian}, A. and {Hathi}, N.~P. and {Ilbert}, O. and {Lemaux}, B.~C. and
+	{Moreau}, C. and {Paltani}, S. and {Ribeiro}, B. and {Salvato}, M. and
+	{Schaerer}, D. and {Scodeggio}, M. and {Sommariva}, V. and {Talia}, M. and
+	{Taniguchi}, Y. and {Tresse}, L. and {Vergani}, D. and {Wang}, P.~W. and
+	{Charlot}, S. and {Contini}, T. and {Fotopoulou}, S. and {L{\'o}pez-Sanjuan}, C. and
+	{Mellier}, Y. and {Scoville}, N.},
+    title = "{The VIMOS Ultra-Deep Survey: \~{}10 000 galaxies with spectroscopic redshifts to study galaxy assembly at early epochs 2 $\lt$ z {\sime} 6}",
+  journal = {\aap},
+archivePrefix = "arXiv",
+   eprint = {1403.3938},
+ keywords = {galaxies: evolution, galaxies: high-redshift, cosmology: observations, large-scale structure of Universe, surveys, galaxies: formation},
+     year = 2015,
+    month = apr,
+   volume = 576,
+      eid = {A79},
+    pages = {A79},
+      doi = {10.1051/0004-6361/201423829},
+   adsurl = {http://adsabs.harvard.edu/abs/2015A\%26A...576A..79L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015A&A...583A..68M,
+  author =       {{Michalik}, D. and {Lindegren}, L. and {Hobbs},
+                  D. and {Butkevich}, A.~G.  },
+  title =        "{Gaia astrometry for stars with too few
+                  observations. A Bayesian approach}",
+  journal =      {\aap},
+  archivePrefix ="arXiv",
+  eprint =       {1507.02963},
+  primaryClass = "astro-ph.IM",
+  keywords =     {astrometry, methods: data analysis, methods:
+                  numerical, parallaxes, proper motions, space
+                  vehicles: instruments},
+  year =         2015,
+  month =        nov,
+  volume =       583,
+  eid =          {A68},
+  pages =        {A68},
+  doi =          {10.1051/0004-6361/201526936},
+  adsurl =       {http://adsabs.harvard.edu/abs/2015A\%26A...583A..68M},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015ApJ...812...18V,
+   author = {{VanderPlas}, J.~T. and {Ivezi{\'c}}, {\v Z}.},
+    title = "{Periodograms for Multiband Astronomical Time Series}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1502.01344},
+ primaryClass = "astro-ph.IM",
+ keywords = {methods: data analysis, methods: statistical, surveys},
+     year = 2015,
+    month = oct,
+   volume = 812,
+      eid = {18},
+    pages = {18},
+      doi = {10.1088/0004-637X/812/1/18},
+   adsurl = {http://adsabs.harvard.edu/abs/2015ApJ...812...18V},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015JInst..10C5010O,
+   author = {{O'Connor}, P.},
+    title = "{Crosstalk in multi-output CCDs for LSST}",
+  journal = {Journal of Instrumentation},
+archivePrefix = "arXiv",
+   eprint = {1501.04137},
+ primaryClass = "astro-ph.IM",
+     year = 2015,
+    month = may,
+   volume = 10,
+      eid = {C05010},
+    pages = {C05010},
+      doi = {10.1088/1748-0221/10/05/C05010},
+   adsurl = {http://adsabs.harvard.edu/abs/2015JInst..10C5010O},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2015arXiv150906868H,
+  author =       {{Hees}, A. and {Hestroffer}, D. and {Le
+                  Poncin-Lafitte}, C. and {David}, P.},
+  title =        "{Tests of gravitation with Gaia observations of
+                  Solar System Objects}",
+  journal =      {ArXiv e-prints},
+  archivePrefix ="arXiv",
+  eprint =       {1509.06868},
+  primaryClass = "gr-qc",
+  keywords =     {General Relativity and Quantum Cosmology,
+                  Astrophysics - Earth and Planetary Astrophysics},
+  year =         2015,
+  month =        sep,
+  adsurl =       {http://adsabs.harvard.edu/abs/2015arXiv150906868H},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016A&A...595A...1G,
+   author = {{Gaia Collaboration} and {Prusti}, T. and {de Bruijne}, J.~H.~J. and
+	{Brown}, A.~G.~A. and {Vallenari}, A. and {Babusiaux}, C. and
+	{Bailer-Jones}, C.~A.~L. and {Bastian}, U. and {Biermann}, M. and
+	{Evans}, D.~W. and et al.},
+    title = "{The Gaia mission}",
+  journal = {\aap},
+archivePrefix = "arXiv",
+   eprint = {1609.04153},
+ primaryClass = "astro-ph.IM",
+ keywords = {space vehicles: instruments, Galaxy: structure, astrometry, parallaxes, proper motions, telescopes},
+     year = 2016,
+    month = nov,
+   volume = 595,
+      eid = {A1},
+    pages = {A1},
+      doi = {10.1051/0004-6361/201629272},
+   adsurl = {http://adsabs.harvard.edu/abs/2016A\%26A...595A...1G},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016ApJ...822...67N,
+   author = {{Narayan}, G. and {Axelrod}, T. and {Holberg}, J.~B. and {Matheson}, T. and
+        {Saha}, A. and {Olszewski}, E. and {Claver}, J. and {Stubbs}, C.~W. and
+        {Bohlin}, R.~C. and {Deustua}, S. and {Rest}, A.},
+    title = "{Toward a Network of Faint DA White Dwarfs as High-precision Spectrophotometric Standards}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1603.03825},
+ primaryClass = "astro-ph.SR",
+ keywords = {cosmology: observations, methods: data analysis, surveys, white dwarfs},
+     year = 2016,
+    month = may,
+   volume = 822,
+      eid = {67},
+    pages = {67},
+      doi = {10.3847/0004-637X/822/2/67},
+   adsurl = {http://adsabs.harvard.edu/abs/2016ApJ...822...67N},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016ApJ...830...27Z,
+   author = {{Zackay}, B. and {Ofek}, E.~O. and {Gal-Yam}, A.},
+    title = "{Proper Image Subtraction{\mdash}Optimal Transient Detection, Photometry, and Hypothesis Testing}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1601.02655},
+ primaryClass = "astro-ph.IM",
+ keywords = {gravitational lensing: micro, methods: data analysis, methods: statistical, surveys, techniques: image processing, techniques: photometric },
+     year = 2016,
+    month = oct,
+   volume = 830,
+      eid = {27},
+    pages = {27},
+      doi = {10.3847/0004-637X/830/1/27},
+   adsurl = {http://adsabs.harvard.edu/abs/2016ApJ...830...27Z},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2016MNRAS.460.1371B,
+   author = {{Beck}, R. and {Dobos}, L. and {Budav{\'a}ri}, T. and {Szalay}, A.~S. and
+	{Csabai}, I.},
+    title = "{Photometric redshifts for the SDSS Data Release 12}",
+  journal = {\mnras},
+archivePrefix = "arXiv",
+   eprint = {1603.09708},
+ keywords = {methods: data analysis, techniques: photometric, catalogues, galaxies: distances and redshifts},
+     year = 2016,
+    month = aug,
+   volume = 460,
+    pages = {1371-1381},
+      doi = {10.1093/mnras/stw1009},
+   adsurl = {http://adsabs.harvard.edu/abs/2016MNRAS.460.1371B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@INPROCEEDINGS{2016SPIE.9913E..1VV,
+  author =       {{Vagg}, D. and {O'Callaghan}, D. and
+                  {O'H{\'o}g{\'a}in}, F. and {McBreen}, S. and
+                  {Hanlon}, L. and {Lynn}, D. and {O'Mullane}, W.  },
+  title =        "{GAVIP: a platform for Gaia data analysis}",
+  booktitle =    {Society of Photo-Optical Instrumentation Engineers
+                  (SPIE) Conference Series},
+  year =         2016,
+  series =       {SPIE},
+  volume =       9913,
+  archivePrefix ="arXiv",
+  eprint =       {1605.09287},
+  primaryClass = "astro-ph.IM",
+  month =        jul,
+  eid =          {99131V},
+  pages =        {99131V},
+  doi =          {10.1117/12.2233619},
+  adsurl =       {http://ads.nao.ac.jp/abs/2016SPIE.9913E..1VV},
+  adsnote =      {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@TECHREPORT{2016acs..rept....1B,
+   author = {{Borncamp}, D. and {Lim}, P.~L.},
+    title = "{Satellite Detection in Advanced Camera for Surveys/Wide Field Channel Images}",
+ keywords = {Hubble Space Telescope, Space Telescope Science Institute, STScI, HST},
+booktitle = {Instrument Science Report ACS 2016-01, 10 pages},
+institution = {STScI},
+     year = 2016,
+    month = jan,
+   adsurl = {http://adsabs.harvard.edu/abs/2016acs..rept....1B},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017arXiv170309824V,
+   author = {{VanderPlas}, J.~T.},
+    title = "{Understanding the Lomb-Scargle Periodogram}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1703.09824},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+     year = 2017,
+    month = mar,
+   adsurl = {http://adsabs.harvard.edu/abs/2017arXiv170309824V},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{2017ApJ...838....5L,
+   author = {{Leistedt}, B. and {Hogg}, D.~W.},
+    title = "{Data-driven, Interpretable Photometric Redshifts Trained on Heterogeneous and Unrepresentative Data}",
+  journal = {\apj},
+archivePrefix = "arXiv",
+   eprint = {1612.00847},
+ keywords = {galaxies: distances and redshifts, large-scale structure of universe, 98.62.Py, 98.80.Es},
+     year = 2017,
+    month = mar,
+   volume = 838,
+      eid = {5},
+    pages = {5},
+      doi = {10.3847/1538-4357/aa6332},
+   adsurl = {http://adsabs.harvard.edu/abs/2017ApJ...838....5L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}


### PR DESCRIPTION
- Include a stub `local.bib` bibliography and a base set of lsst-texmf bibliographies in `lsstbib/`.
- In conjunction with the DM-6033 ticket for documenteer (lsst-sqre/documenteer/pull/16), the `make refresh-bib` command makes it easy to update the managed bibliographies.
- Include stubs for using the `bibliography` directive in the index.rst template. It's not active by default, but it should be easy to uncomment that section when bibtex is being used for references.