### PR TITLE
DM-14360: Remove latex+latin encoding for bibliography dir

### DIFF
--- a/{{cookiecutter.repo_name}}/index.rst
+++ b/{{cookiecutter.repo_name}}/index.rst
@@ -58,5 +58,4 @@
 .. Make in-text citations with: :cite:`bibkey`.
 
 .. .. bibliography:: local.bib lsstbib/books.bib lsstbib/lsst.bib lsstbib/lsst-dm.bib lsstbib/refs.bib lsstbib/refs_ads.bib
-..    :encoding: latex+latin
 ..    :style: lsst_aa


### PR DESCRIPTION
In new versions of sphinxcontrib-bibtex and its dependencies, the latex+latin encoding is no longer needed (and in fact, is an error if present):

```
unknown encoding: "latex+latin"
```