### PR TITLE
DM-16651: Bump documenteer to 0.4.x release

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements.txt
+++ b/{{cookiecutter.repo_name}}/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]>=0.2.1,<0.3
+documenteer[technote]>=0.4.3,<0.5.0


### PR DESCRIPTION
This is to support compatibility between the pinned Sphinx and sphinxcontrib-bibtex.